### PR TITLE
docs: integrate skill concepts into M3 design

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -452,6 +452,41 @@ failed  = any(c["conclusion"] in ("failure", "error") for c in checks)
 ```
 On failure: fetches `gh run view --log-failed` (last 150 lines), invokes coder with `PromptBuilder.ci_fix_prompt()`, pushes fixes, re-polls. After `max_ci_fix_rounds` failures: raises `CIFailedFatal`.
 
+### `DiscoveryWizard`
+Used by `ralph init`. Asks exactly 6 questions interactively:
+
+1. One-sentence product description
+2. Language, runtime, package manager
+3. Test framework + coverage tool
+4. Quality gate commands (pre-commit, lint, test commands that will populate `quality_checks`)
+5. Any human-only steps (credentials, infra provisioning — these become `owner: "human"` tasks)
+6. What is explicitly out of scope for this sprint
+
+Produces a `ProjectSpec` dataclass. Does **not** call AI — pure interactive I/O. Rationale: `/grill-me` is open-ended and relentless; `DiscoveryWizard` is tight and ralph-specific. 6 questions is enough to generate a valid `prd.json` scaffold without over-engineering.
+
+### `PrdValidator`
+Shared validation layer used by both `PrdGenerator` and `PlanChecker` (Tier 1). Enforces:
+
+1. `description` ≥ 100 chars
+2. At least one acceptance criterion references a file path (e.g. `tests/`, `.py`)
+3. No credential strings in ralph-owned tasks (regex: `password|secret|token|key` in description)
+4. All `depends_on` IDs exist somewhere in `prd.json`
+
+Raises `PlanInvalidError` with specific field + reason on any failure. Kept separate from `PlanChecker` so `PrdGenerator` can validate before appending without instantiating the full plan checker.
+
+### `PrdGenerator`
+Used by `ralph add`. Accepts a natural language spec string or a GitHub issue URL. If a URL is passed, fetches issue body via `gh issue view`. Calls `AIRunner` with `PromptBuilder.prd_generate_prompt()` to produce task JSON, then runs `PrdValidator` before appending to `prd.json` via `TaskTracker.add_task()`. Infers the next epic prefix from the highest existing task ID. Mirrors the `/ralph-prd` skill logic but as a typed Python class.
+
+### `PlanConsensus`
+Used by `ralph plan`. Lightweight Planner + Critic loop (max 3 iterations), analogous to `/ralplan` but without an Architect agent:
+
+1. **Planner** agent: produce a work plan from the `ProjectSpec`
+2. **Critic** agent: review against quality gates — measurable ACs, atomic tasks, no vague language
+3. If **REJECT**: send Critic feedback to Planner, increment iteration
+4. If **OKAY** or max iterations: write plan to `ralph-plan.md` and return
+
+Key difference from `/ralplan`: no Architect agent. For complex architectural decisions users can run `/ralplan` interactively first, then pass the result to `ralph plan`.
+
 ### `Orchestrator`
 Main loop. Composes everything. `_preflight()` validates tools, auth, SSH remote, prd.json structure, then runs `PlanChecker.run()` — raising `PlanInvalidError` on structural errors, logging warnings if `--validate-plan` was passed. `_run_task()` is the per-iteration state machine (see below).
 

--- a/SCRUM_MASTER.md
+++ b/SCRUM_MASTER.md
@@ -38,6 +38,21 @@ If any of these fail, fix them before starting the loop — the loop will abort 
 
 ---
 
+## Workflow skills (Claude Code only)
+
+These Claude Code skills complement the loop. Use them **before** `bash ralph-loop.sh` starts, or between sprints. They do not survive outside a Claude session — they are interaction tools, not automation.
+
+| Skill | When to use |
+|---|---|
+| `/loop 10m <monitor command>` | Schedule a status check (e.g. `tail -5 ralph-loop.log`) to run every 10 minutes while the loop is running unattended |
+| `/ralph-planner` | Run a guided 8-question discovery interview to produce a `prd.json` from scratch — use when starting a brand-new project with no existing backlog |
+| `/ralph-prd` | Convert a feature spec or GitHub issue list into tasks and append them to `prd.json` — use when adding a new epic mid-project |
+| `/grill-me` | Stress-test a plan or design before committing it to `prd.json` — surfaces assumptions and contradictions early |
+
+These are complements, not replacements — `ralph-planner` and `ralph-prd` are superseded by `ralph init` and `ralph add` once M3 is built.
+
+---
+
 ## Starting a sprint
 
 ```bash
@@ -54,7 +69,7 @@ bash ralph-loop.sh --opencode-only --skip-review --task M1-01
 bash ralph-loop.sh --opencode-only --skip-review --resume --max 10
 ```
 
-**Key rule**: if you are running inside a Claude Code session, always use `--skip-review`. The reviewer step silently fails in nested Claude sessions (see DESIGN.md lesson #8). CI is the quality gate.
+**Key rule**: never use `--skip-review` — it removes the code review entirely and leaves CI as the only quality gate. Use `--opencode-coder-model` / `--opencode-reviewer-model` to route both agents through opencode so neither depends on a nested Claude session (see DESIGN.md lesson #8).
 
 ---
 

--- a/prd.json
+++ b/prd.json
@@ -533,6 +533,90 @@
       "depends_on": ["M1-01", "M1-02", "M1-03", "M1-04", "M1-05", "M1-06", "M1-07", "M1-08", "M1-09", "M1-10", "M1-11", "M1-12", "M1-13", "M1-14", "M1-15", "M1-16", "M1-17b", "M1-18c"],
       "completed": false,
       "priority": 23
+    },
+    {
+      "id": "M3-01",
+      "epic": "M3",
+      "title": "ralph_init_discovery_wizard",
+      "owner": "ralph",
+      "complexity": 2,
+      "description": "Implement the 'ralph init' CLI command and DiscoveryWizard class. DiscoveryWizard asks 6 interactive questions (product description, language/runtime/package-manager, test framework + coverage tool, quality gate commands, human-only steps, out-of-scope items) and produces a ProjectSpec dataclass. 'ralph init' uses ProjectSpec to write: prd.json scaffold (with epic_addenda and quality_checks populated), CODER_INSTRUCTIONS.md, REVIEWER_INSTRUCTIONS.md, and a git hook blocking direct commits to main. No AI calls — pure interactive I/O. See DESIGN.md: DiscoveryWizard.",
+      "acceptance_criteria": [
+        "DiscoveryWizard(io: IO) class with a run() -> ProjectSpec method that asks exactly 6 questions in order",
+        "ProjectSpec dataclass with fields: description, language, runtime, package_manager, test_framework, coverage_tool, quality_checks (list[str]), human_steps (list[str]), out_of_scope (list[str])",
+        "'ralph init' click command invokes DiscoveryWizard, writes prd.json scaffold with epic_addenda and quality_checks from ProjectSpec, writes CODER_INSTRUCTIONS.md and REVIEWER_INSTRUCTIONS.md to the repo root",
+        "Git hook written to .git/hooks/pre-push that blocks direct pushes to main with a clear error message",
+        "prd.json scaffold includes: project name (from description), quality_checks from ProjectSpec answers, empty tasks list, epic_addenda stub",
+        "Human-only steps from question 5 become owner: 'human' placeholder tasks in the generated prd.json",
+        "Tests use monkeypatch/mock for stdin; verify ProjectSpec fields match answers; verify prd.json and instruction files are created; verify git hook file exists and is executable"
+      ],
+      "files": ["ralph.py", "tests/test_discovery_wizard.py"],
+      "depends_on": ["M1-19"],
+      "completed": false,
+      "priority": 24
+    },
+    {
+      "id": "M3-02",
+      "epic": "M3",
+      "title": "prd_validator",
+      "owner": "ralph",
+      "complexity": 1,
+      "description": "Implement PrdValidator: shared validation layer used by both PrdGenerator (M3-03) and PlanChecker. Enforces 4 rules: description >= 100 chars; at least one AC references a file path (contains '.py', 'tests/', or a filename pattern); no credential strings in ralph-owned task descriptions (regex: password|secret|token|api.?key, case-insensitive); all depends_on IDs exist in the tasks list. Raises PlanInvalidError with field name and reason on any failure. See DESIGN.md: PrdValidator.",
+      "acceptance_criteria": [
+        "PrdValidator class with validate(task: dict, all_task_ids: set[str]) -> None method",
+        "Rule 1: raises PlanInvalidError if task description is shorter than 100 characters",
+        "Rule 2: raises PlanInvalidError if no acceptance criterion contains a file path pattern (r'[\\w/]+\\.py|tests/')",
+        "Rule 3: raises PlanInvalidError if description matches r'(?i)(password|secret|api.?key|token)' for ralph-owned tasks",
+        "Rule 4: raises PlanInvalidError if any depends_on ID is not in all_task_ids",
+        "PlanChecker.check_structural() calls PrdValidator.validate() for each incomplete task instead of duplicating the logic",
+        "Tests: each rule has a dedicated test — short description fails R1, description without file ref fails R2, description with 'secret' fails R3, unknown depends_on ID fails R4, valid task passes all rules"
+      ],
+      "files": ["ralph.py", "tests/test_prd_validator.py"],
+      "depends_on": ["M1-01", "M1-05"],
+      "completed": false,
+      "priority": 25
+    },
+    {
+      "id": "M3-03",
+      "epic": "M3",
+      "title": "prd_generator_ralph_add",
+      "owner": "ralph",
+      "complexity": 2,
+      "description": "Implement PrdGenerator class and 'ralph add' CLI command. PrdGenerator accepts a natural language spec string or a GitHub issue URL. If a URL matching r'github\\.com/.+/issues/\\d+' is detected, fetches the issue body via 'gh issue view <number> --json title,body'. Calls AIRunner.run_reviewer() with PromptBuilder.prd_generate_prompt() to produce a JSON list of task dicts, validates each via PrdValidator, then appends to prd.json via TaskTracker.add_task(). Infers next epic prefix from highest existing task ID. See DESIGN.md: PrdGenerator.",
+      "acceptance_criteria": [
+        "PrdGenerator(ai_runner: AIRunner, task_tracker: TaskTracker, validator: PrdValidator, runner: SubprocessRunner, logger: RalphLogger) constructor",
+        "generate(spec: str) -> list[dict]: detects GitHub issue URL, fetches body via gh CLI if URL, calls AIRunner with prd_generate_prompt, parses JSON response, validates each task via PrdValidator, appends to prd.json via TaskTracker.add_task()",
+        "PromptBuilder.prd_generate_prompt(spec: str, existing_tasks: list[dict]) -> str: includes existing task IDs and max epic prefix so AI generates correct IDs and depends_on chains",
+        "'ralph add' click command accepts a positional spec argument (string or URL), instantiates PrdGenerator, calls generate(), prints count of tasks added",
+        "Epic prefix inference: scans existing task IDs for highest Mx prefix, increments x for new tasks (e.g. if max is M1, new tasks get M2 prefix)",
+        "Tests mock AIRunner and SubprocessRunner; verify GitHub URL detection; verify PrdValidator called for each generated task; verify TaskTracker.add_task called N times"
+      ],
+      "files": ["ralph.py", "tests/test_prd_generator.py"],
+      "depends_on": ["M1-10", "M3-02"],
+      "completed": false,
+      "priority": 26
+    },
+    {
+      "id": "M3-04",
+      "epic": "M3",
+      "title": "plan_consensus_ralph_plan",
+      "owner": "ralph",
+      "complexity": 2,
+      "description": "Implement PlanConsensus class and 'ralph plan' CLI command. PlanConsensus runs a Planner + Critic loop (max 3 iterations): Planner agent produces a work plan from a ProjectSpec or free-text brief; Critic agent reviews against quality gates (measurable ACs, atomic tasks, no vague language like 'improve' or 'enhance'); on REJECT the Critic feedback is sent back to the Planner; on OKAY or after 3 iterations the plan is written to ralph-plan.md and returned. See DESIGN.md: PlanConsensus.",
+      "acceptance_criteria": [
+        "PlanConsensus(ai_runner: AIRunner, logger: RalphLogger, config: Config) constructor",
+        "run(brief: str, max_iterations: int = 3) -> str: Planner produces plan, Critic reviews, loops on REJECT up to max_iterations, returns final plan text",
+        "PromptBuilder.planner_prompt(brief: str, feedback: str = '') -> str: includes brief and any prior Critic feedback",
+        "PromptBuilder.critic_prompt(plan: str) -> str: instructs Critic to output OKAY or REJECT with specific line-level reasons; checks for vague verbs (improve, enhance, refactor, fix) without measurable outcomes",
+        "Critic verdict parsing: REJECT takes precedence if both strings appear; unclear verdict treated as OKAY with warning logged",
+        "After loop: writes plan to ralph-plan.md in repo root; logs iteration count and final verdict",
+        "'ralph plan' click command accepts optional --brief TEXT argument (or reads from stdin if omitted), calls PlanConsensus.run(), prints path to ralph-plan.md",
+        "Tests mock AIRunner; verify REJECT loops correctly; verify OKAY exits early; verify ralph-plan.md written; verify max_iterations respected"
+      ],
+      "files": ["ralph.py", "tests/test_plan_consensus.py"],
+      "depends_on": ["M1-10", "M3-02"],
+      "completed": false,
+      "priority": 27
     }
   ]
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -76,11 +76,15 @@ Deliver the full architecture from the rewrite plan as a single working Python f
 
 ### Deliverables
 
-- [ ] `ralph init` command — interactive setup that produces:
+- [ ] `ralph init` command — interactive setup via `DiscoveryWizard` (6-question grill-me lite) that produces:
   - `prd.json` scaffold (with `epic_addenda`, `quality_checks`, empty task list)
   - `CODER_INSTRUCTIONS.md` customised to the project's stack
   - `REVIEWER_INSTRUCTIONS.md`
   - Git hook that blocks commits directly to main
+- [ ] `DiscoveryWizard` — 6-question interactive I/O class; no AI; produces `ProjectSpec` dataclass
+- [ ] `PrdValidator` — 4-rule validation (description length, file-path AC, no credentials, valid depends_on); shared by `PlanChecker` and `PrdGenerator`
+- [ ] `ralph add` command — `PrdGenerator` class; converts free-text spec or GitHub issue URL → validated tasks appended to `prd.json`
+- [ ] `ralph plan` command — `PlanConsensus` class; Planner + Critic loop (max 3 iter); writes `ralph-plan.md`
 - [ ] `pipx`-installable package — `pipx install ralphzilla` → `ralph` available globally
 - [ ] README — quickstart, `prd.json` schema reference, CLI flag reference, worked example
 - [ ] Schema validation on `prd.json` load — clear error messages for malformed files
@@ -186,6 +190,7 @@ M3 (DX) is deliberately before M4 (Scrum Master) because without a clean init st
 | Plan validation | M1 (structural) + M2 (AI) |
 | Failure recovery | M1 (CI/review) + M4 (Scrum Master) |
 | Installation / `init` | M3 |
+| Spec-driven planning (Discuss/Plan phase) | M3 (`ralph plan` + `ralph add`) |
 | Documentation | M3 |
 | Tests | M2 |
 | Sprint supervision | M4 |


### PR DESCRIPTION
Implements the skill integration plan:

- **SCRUM_MASTER.md**: adds Workflow Skills section documenting `/loop`, `/ralph-planner`, `/ralph-prd`, `/grill-me`; corrects the `--skip-review` key rule (use opencode models, not skip-review)
- **DESIGN.md**: adds `DiscoveryWizard`, `PrdValidator`, `PrdGenerator`, `PlanConsensus` class specs before `Orchestrator`
- **prd.json**: adds M3-01 through M3-04 tasks with full ACs and correct `depends_on` chains
- **roadmap.md**: expands M3 deliverables list; adds GSD parity row for spec-driven planning