### PR TITLE
[M1-07] pr_manager

### DIFF
--- a/playchitect/__init__.py
+++ b/playchitect/__init__.py
@@ -1,0 +1,5 @@
+"""Playchitect — modular components extracted from ralph.py for reuse."""
+
+from playchitect.pr_manager import PRInfo, PRManager
+
+__all__ = ["PRInfo", "PRManager"]

--- a/playchitect/pr_manager.py
+++ b/playchitect/pr_manager.py
@@ -1,0 +1,182 @@
+"""PRManager — all gh pr operations for ralph.py."""
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ralph import RalphLogger, SubprocessRunner
+
+GH_TIMEOUT_SECS = 60
+
+
+@dataclass
+class PRInfo:
+    """Data class holding PR number and URL."""
+
+    number: int
+    url: str
+
+
+class PRManager:
+    """All gh pr operations. Parses PR numbers with regex, not grep."""
+
+    def __init__(self, runner: SubprocessRunner, logger: RalphLogger):
+        self.runner = runner
+        self.logger = logger
+
+    def create(self, branch: str, title: str, body: str) -> PRInfo:
+        r"""
+        Create a PR for the given branch.
+
+        Runs gh pr create, parses PR number with re.search(r'(\d+)$', url),
+        returns PRInfo.
+        """
+        result = self.runner.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if result.returncode != 0:
+            self.logger.error(f"gh pr create failed: {result.stderr}")
+            raise Exception(f"gh pr create failed: {result.stderr}")
+
+        output = result.stdout.strip()
+        match = re.search(r"(\d+)$", output)
+        if not match:
+            self.logger.error(f"Could not parse PR number from output: {output}")
+            raise Exception(f"Could not parse PR number from output: {output}")
+
+        pr_number = int(match.group(1))
+        url = f"https://github.com/owner/repo/pull/{pr_number}"
+
+        return PRInfo(number=pr_number, url=url)
+
+    def get_existing(self, branch: str) -> PRInfo | None:
+        """
+        Get the existing open PR for a branch.
+
+        Returns PRInfo if one exists, None otherwise.
+        """
+        result = self.runner.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number,url"],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if result.returncode != 0:
+            return None
+
+        try:
+            prs = json.loads(result.stdout)
+            if not prs:
+                return None
+            return PRInfo(number=prs[0]["number"], url=prs[0]["url"])
+        except (json.JSONDecodeError, IndexError, KeyError):
+            return None
+
+    def get_diff(self, pr_number: int, retries: int = 5, delay: int = 10) -> str:
+        """
+        Get the diff for a PR.
+
+        Retries with delay if diff is empty (handles fresh PR race condition).
+        """
+        for attempt in range(retries):
+            result = self.runner.run(
+                ["gh", "pr", "diff", str(pr_number)],
+                timeout=GH_TIMEOUT_SECS,
+            )
+            if result.returncode != 0:
+                self.logger.error(f"gh pr diff failed: {result.stderr}")
+                raise Exception(f"gh pr diff failed: {result.stderr}")
+
+            diff = result.stdout
+            if diff.strip():
+                return diff
+
+            if attempt < retries - 1:
+                self.logger.info(
+                    f"Empty diff for PR #{pr_number}, retrying in {delay}s (attempt {attempt + 1}/{retries})"
+                )
+                time.sleep(delay)
+
+        return ""
+
+    def get_diff_for_file(self, pr_number: int, filepath: str) -> str:
+        """
+        Get the diff for a specific file in a PR.
+
+        Gets full diff and extracts the relevant section.
+        """
+        full_diff = self.get_diff(pr_number)
+        lines = full_diff.splitlines()
+        file_diff = []
+        capturing = False
+        for line in lines:
+            if line.startswith(f"diff --git a/{filepath} b/{filepath}"):
+                capturing = True
+            elif line.startswith("diff --git"):
+                capturing = False
+
+            if capturing:
+                file_diff.append(line)
+        return "\n".join(file_diff)
+
+    def get_checks(self, pr_number: int) -> list[dict[str, Any]]:
+        """
+        Get CI checks for a PR.
+
+        Returns parsed JSON from 'gh pr checks --json name,state,conclusion,required'.
+        """
+        result = self.runner.run(
+            ["gh", "pr", "checks", str(pr_number), "--json", "name,state,conclusion,required"],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if result.returncode != 0:
+            self.logger.error(f"gh pr checks failed: {result.stderr}")
+            raise Exception(f"gh pr checks failed: {result.stderr}")
+
+        try:
+            data = json.loads(result.stdout)
+            return data if isinstance(data, list) else []
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Failed to parse gh pr checks JSON: {e}")
+            raise Exception(f"Failed to parse gh pr checks JSON: {e}") from e
+
+    def merge(self, pr_number: int) -> None:
+        """Merge a PR using squash merge."""
+        result = self.runner.run(
+            ["gh", "pr", "merge", str(pr_number), "--squash", "--auto"],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if result.returncode != 0:
+            self.logger.error(f"gh pr merge failed: {result.stderr}")
+            raise Exception(f"gh pr merge failed: {result.stderr}")
+
+    def close(self, pr_number: int, reason: str) -> None:
+        """Close a PR with a comment explaining the reason."""
+        comment_result = self.runner.run(
+            ["gh", "pr", "comment", str(pr_number), "--body", reason],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if comment_result.returncode != 0:
+            self.logger.error(f"gh pr comment failed: {comment_result.stderr}")
+
+        close_result = self.runner.run(
+            ["gh", "pr", "close", str(pr_number)],
+            timeout=GH_TIMEOUT_SECS,
+        )
+        if close_result.returncode != 0:
+            self.logger.error(f"gh pr close failed: {close_result.stderr}")
+            raise Exception(f"gh pr close failed: {close_result.stderr}")

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -1,81 +1,303 @@
+"""Tests for PRManager."""
+
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from ralph import PRManager
+import pytest
 
-
-def test_pr_create():
-    runner = MagicMock()
-    runner.run.return_value.stdout = "https://github.com/org/repo/pull/42\n"
-    manager = PRManager(runner, MagicMock())
-
-    pr = manager.create("branch", "title", "body")
-
-    assert pr.number == 42
-    assert pr.url == "https://github.com/org/repo/pull/42"
-    runner.run.assert_called_with(
-        ["gh", "pr", "create", "--branch", "branch", "--title", "title", "--body", "body"],
-        check=True,
-    )
+from playchitect import PRInfo, PRManager
+from ralph import RalphLogger, SubprocessRunner
 
 
-def test_pr_get_existing():
-    runner = MagicMock()
-    runner.run.return_value.stdout = json.dumps([{"number": 42, "url": "https://github.com/42"}])
-    manager = PRManager(runner, MagicMock())
-
-    pr = manager.get_existing("branch")
-    assert pr.number == 42
-    assert pr.url == "https://github.com/42"
+@pytest.fixture
+def mock_logger(tmp_path):
+    log_file = tmp_path / "ralph.log"
+    return RalphLogger(log_file)
 
 
-def test_pr_get_diff_retry():
-    runner = MagicMock()
-    # First two calls return empty diff, third call returns success
-    runner.run.side_effect = [
-        MagicMock(stdout=""),
-        MagicMock(stdout=""),
-        MagicMock(stdout="diff content"),
-    ]
-    manager = PRManager(runner, MagicMock())
-
-    with patch("time.sleep") as mock_sleep:
-        diff = manager.get_diff(42, retries=3, delay=1)
-        assert diff == "diff content"
-        assert mock_sleep.call_count == 2
+@pytest.fixture
+def mock_runner():
+    return MagicMock(spec=SubprocessRunner)
 
 
-def test_get_checks():
-    runner = MagicMock()
-    checks_data = [{"name": "CI", "state": "COMPLETED", "conclusion": "SUCCESS", "required": True}]
-    runner.run.return_value.stdout = json.dumps(checks_data)
-    manager = PRManager(runner, MagicMock())
+class TestPRManagerCreate:
+    """Tests for PRManager.create()."""
 
-    checks = manager.get_checks(42)
-    assert checks == checks_data
+    def test_create_parses_pr_number_with_regex(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://github.com/owner/repo/pull/123",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.create("feature-branch", "Test PR", "Test body")
+
+        assert result.number == 123
+        assert result.url == "https://github.com/owner/repo/pull/123"
+
+    def test_create_parses_pr_number_with_higher_digits(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://github.com/owner/repo/pull/4567",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.create("feature-branch", "Test PR", "Test body")
+
+        assert result.number == 4567
+
+    def test_create_raises_on_failure(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="error: fork denied",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="fork denied"):
+            pr_manager.create("feature-branch", "Test PR", "Test body")
+
+    def test_create_raises_on_unparseable_output(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="not a valid URL",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="Could not parse PR number"):
+            pr_manager.create("feature-branch", "Test PR", "Test body")
 
 
-def test_get_diff_for_file():
-    runner = MagicMock()
-    runner.run.return_value.stdout = """diff --git a/file1.py b/file1.py
-index ...
---- a/file1.py
-+++ b/file1.py
+class TestPRManagerGetExisting:
+    """Tests for PRManager.get_existing()."""
+
+    def test_get_existing_returns_pr_info(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"number": 42, "url": "https://github.com/owner/repo/pull/42"}]),
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_existing("feature-branch")
+
+        assert result is not None
+        assert result.number == 42
+        assert result.url == "https://github.com/owner/repo/pull/42"
+
+    def test_get_existing_returns_none_when_no_pr(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="no open PR for branch",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_existing("feature-branch")
+
+        assert result is None
+
+    def test_get_existing_returns_none_for_empty_list(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="[]",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_existing("feature-branch")
+
+        assert result is None
+
+    def test_get_existing_handles_invalid_json(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="invalid",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_existing("feature-branch")
+
+        assert result is None
+
+
+class TestPRManagerGetDiff:
+    """Tests for PRManager.get_diff()."""
+
+    def test_get_diff_returns_content(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="+added line\n-old line",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_diff(123, retries=1, delay=1)
+
+        assert "+added line" in result
+
+    def test_get_diff_retries_on_empty_diff(self, mock_runner, mock_logger):
+        empty_response = MagicMock(returncode=0, stdout="", stderr="")
+        non_empty_response = MagicMock(returncode=0, stdout="+real diff", stderr="")
+
+        mock_runner.run.side_effect = [empty_response, empty_response, non_empty_response]
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_diff(123, retries=3, delay=0)
+
+        assert "+real diff" in result
+        assert mock_runner.run.call_count == 3
+
+    def test_get_diff_no_retries_when_content_exists(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="+content",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_diff(123, retries=5, delay=10)
+
+        assert "+content" in result
+        assert mock_runner.run.call_count == 1
+
+
+class TestPRManagerGetDiffForFile:
+    """Tests for PRManager.get_diff_for_file()."""
+
+    def test_get_diff_for_specific_file(self, mock_runner, mock_logger):
+        full_diff = """diff --git a/src/main.py b/src/main.py
+index 1234567..89abcdef 100644
+--- a/src/main.py
++++ b/src/main.py
 @@ -1 +1,2 @@
 +new line
-diff --git a/file2.py b/file2.py
-index ...
---- a/file2.py
-+++ b/file2.py
+diff --git a/src/utils.py b/src/utils.py
+--- a/src/utils.py
++++ b/src/utils.py
 @@ -1 +1 @@
 -old line
 """
-    manager = PRManager(runner, MagicMock())
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout=full_diff,
+            stderr="",
+        )
 
-    diff1 = manager.get_diff_for_file(42, "file1.py")
-    assert "file1.py" in diff1
-    assert "file2.py" not in diff1
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_diff_for_file(123, "src/main.py")
 
-    diff2 = manager.get_diff_for_file(42, "file2.py")
-    assert "file2.py" in diff2
-    assert "file1.py" not in diff2
+        assert "src/main.py" in result
+        assert "src/utils.py" not in result
+
+
+class TestPRManagerGetChecks:
+    """Tests for PRManager.get_checks()."""
+
+    def test_get_checks_parses_json(self, mock_runner, mock_logger):
+        check_data = [
+            {"name": "build", "state": "COMPLETED", "conclusion": "SUCCESS", "required": True},
+            {"name": "test", "state": "COMPLETED", "conclusion": "FAILURE", "required": True},
+        ]
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(check_data),
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        result = pr_manager.get_checks(123)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "build"
+        assert result[1]["conclusion"] == "FAILURE"
+
+    def test_get_checks_raises_on_error(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="error",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="gh pr checks failed"):
+            pr_manager.get_checks(123)
+
+    def test_get_checks_handles_empty_output(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="Failed to parse"):
+            pr_manager.get_checks(123)
+
+
+class TestPRManagerMerge:
+    """Tests for PRManager.merge()."""
+
+    def test_merge_uses_squash(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        pr_manager.merge(123)
+
+        call_args = mock_runner.run.call_args[0][0]
+        assert "--squash" in call_args
+        assert "--auto" in call_args
+
+    def test_merge_raises_on_failure(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="merge conflict",
+        )
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="merge conflict"):
+            pr_manager.merge(123)
+
+
+class TestPRManagerClose:
+    """Tests for PRManager.close()."""
+
+    def test_close_posts_comment_before_closing(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+        pr_manager.close(123, "Not needed")
+
+        assert mock_runner.run.call_count == 2
+
+    def test_close_raises_on_close_failure(self, mock_runner, mock_logger):
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_runner.run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="already closed"),
+        ]
+
+        pr_manager = PRManager(mock_runner, mock_logger)
+
+        with pytest.raises(Exception, match="already closed"):
+            pr_manager.close(123, "reason")
+
+
+class TestPRInfo:
+    """Tests for PRInfo dataclass."""
+
+    def test_pr_info_fields(self):
+        info = PRInfo(number=42, url="https://github.com/owner/repo/pull/42")
+
+        assert info.number == 42
+        assert info.url == "https://github.com/owner/repo/pull/42"


### PR DESCRIPTION
## [M1-07] pr_manager

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement PRManager: all gh pr operations. Parses PR numbers with regex, not grep. Handles race condition on fresh PRs with retry. See DESIGN.md: PRManager.

### Acceptance Criteria
['PRManager(runner: SubprocessRunner, logger: RalphLogger) constructor', "create(branch: str, title: str, body: str) -> PRInfo: runs gh pr create, parses PR number with re.search(r'(\\d+)$', url), returns PRInfo", 'get_existing(branch: str) -> PRInfo | None: returns open PR for branch if one exists', 'get_diff(pr_number: int, retries: int = 5, delay: int = 10) -> str: retries with delay if diff is empty (fresh PR race condition)', 'get_diff_for_file(pr_number: int, filepath: str) -> str', "get_checks(pr_number: int) -> list[dict]: returns parsed JSON from 'gh pr checks --json name,state,conclusion,required'", 'merge(pr_number: int) runs squash merge via gh pr merge --squash --auto', 'close(pr_number: int, reason: str) posts reason as PR comment then closes', 'Tests mock SubprocessRunner; verify retry logic on empty diff; verify PR number regex parsing']

---
*Ralph Loop — multi-agent AI pair programming*