### PR TITLE
[M1-09] prompt_builder

### DIFF
--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -14,6 +14,8 @@ def test_coder_prompt():
     prompt = PromptBuilder.coder_prompt(task, "Claude", prd)
     assert "Task 1" in prompt
     assert "AC1" in prompt
+    assert "1." in prompt
+    assert "2." in prompt
     assert "file1.py" in prompt
     assert "Addendum 1" in prompt
     assert "Do NOT touch prd.json" in prompt
@@ -25,12 +27,26 @@ def test_coder_prompt_resume():
     assert "already has commits" in prompt
 
 
-def test_reviewer_prompt():
+def test_reviewer_prompt_with_addenda():
+    task = {"title": "T1", "description": "D1", "epic": "GUI"}
+    prd = {"epic_addenda": {"GUI": "Check for GTK4 runtime errors."}}
+    prompt = PromptBuilder.reviewer_prompt(task, "diff content", prd, 1)
+    assert "Correctness" in prompt
+    assert "Security" in prompt
+    assert "Performance" in prompt
+    assert "Maintainability" in prompt
+    assert "Testing" in prompt
+    assert "PRD adherence" in prompt
+    assert "GTK4 runtime" in prompt
+    assert "APPROVED" in prompt
+    assert "CHANGES REQUESTED" in prompt
+    assert "file+line" in prompt
+
+
+def test_reviewer_prompt_without_addenda():
     task = {"title": "T1", "description": "D1"}
     prompt = PromptBuilder.reviewer_prompt(task, "diff", {}, 1)
     assert "Correctness" in prompt
-    assert "APPROVED" in prompt
-    assert "CHANGES REQUESTED" in prompt
 
 
 def test_test_writer_prompt():
@@ -38,6 +54,14 @@ def test_test_writer_prompt():
     prompt = PromptBuilder.test_writer_prompt(task)
     assert "Write failing tests only" in prompt
     assert "Do NOT implement the module" in prompt
+    assert "ImportError or AssertionError" in prompt
+
+
+def test_test_quality_prompt():
+    task = {"title": "T1", "acceptance_criteria": ["AC1"]}
+    prompt = PromptBuilder.test_quality_prompt(task, "test source", "ast report")
+    assert "HOLLOW" in prompt
+    assert "AC1" in prompt
 
 
 def test_decompose_prompt():
@@ -45,3 +69,53 @@ def test_decompose_prompt():
     prompt = PromptBuilder.decompose_prompt(task)
     assert "Break the following complexity-3 task" in prompt
     assert "JSON list" in prompt
+
+
+def test_plan_check_prompt():
+    tasks = [{"id": "T1", "title": "Task 1"}]
+    prompt = PromptBuilder.plan_check_prompt(tasks)
+    assert "[WARN]" in prompt
+    assert "not atomic" in prompt
+    assert "untestable" in prompt
+
+
+def test_precommit_fix_prompt():
+    task = {"title": "Task 1"}
+    prompt = PromptBuilder.precommit_fix_prompt(task, "error output")
+    assert "Task 1" in prompt
+    assert "pre-commit" in prompt
+    assert "error output" in prompt
+
+
+def test_test_fix_prompt():
+    task = {"title": "Task 1"}
+    prompt = PromptBuilder.test_fix_prompt(task, "test failure")
+    assert "Task 1" in prompt
+    assert "failed" in prompt
+
+
+def test_review_fix_prompt():
+    task = {"title": "Task 1"}
+    prompt = PromptBuilder.review_fix_prompt(task, "fix this")
+    assert "Task 1" in prompt
+    assert "fix this" in prompt
+
+
+def test_ci_fix_prompt():
+    task = {"title": "Task 1"}
+    prompt = PromptBuilder.ci_fix_prompt(task, "CI log")
+    assert "Task 1" in prompt
+    assert "CI" in prompt
+
+
+def test_pr_body():
+    task = {
+        "title": "Task 1",
+        "description": "Task description",
+        "acceptance_criteria": ["AC1", "AC2"],
+    }
+    prompt = PromptBuilder.pr_body(task)
+    assert "Task 1" in prompt
+    assert "Task description" in prompt
+    assert "[ ] AC1" in prompt
+    assert "[ ] AC2" in prompt


### PR DESCRIPTION
## [M1-09] prompt_builder

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement PromptBuilder: all prompt templates as pure static methods. No logic here — stateless text assembly only. Includes epic_addenda injection, TDD prompts, and decomposition prompt. See DESIGN.md: PromptBuilder.

### Acceptance Criteria
['PromptBuilder has no __init__ and no instance state — all methods are @staticmethod', 'coder_prompt(task: dict, coder: str, prd: dict, resume: bool = False) -> str: includes task description, all ACs numbered, files list, epic_addenda if task epic matches prd epic_addenda, explicit instruction not to touch prd.json/progress.txt, and resume note if resume=True', 'precommit_fix_prompt(task: dict, precommit_output: str) -> str', 'test_fix_prompt(task: dict, test_output: str) -> str', 'reviewer_prompt(task: dict, diff: str, prd: dict, round_num: int) -> str: includes all 6 review categories, epic_addenda if present, instruction to output APPROVED or CHANGES REQUESTED with file:line references', 'review_fix_prompt(task: dict, review_text: str) -> str', 'ci_fix_prompt(task: dict, failure_log: str) -> str', 'pr_body(task: dict) -> str', 'plan_check_prompt(tasks: list[dict]) -> str: asks AI to flag [WARN] untestable ACs, non-atomic tasks, contradictions', 'test_writer_prompt(task: dict) -> str: instructs agent to write FAILING tests only, not to implement the module under test, tests must fail with ImportError or AssertionError', "test_quality_prompt(task: dict, test_source: str, ast_report: str) -> str: asks AI to flag [HOLLOW] tests that don't genuinely verify their AC", 'decompose_prompt(task: dict) -> str: asks AI to break task into 2-4 atomic subtasks as JSON list', 'Tests verify each prompt contains required keywords/sections; reviewer_prompt includes addendum when epic_addenda key matches task epic']

---
*Ralph Loop — multi-agent AI pair programming*