### PR TITLE
[M1-10] ai_runner

### DIFF
--- a/tests/test_ai_runner.py
+++ b/tests/test_ai_runner.py
@@ -67,3 +67,60 @@ def test_clean_output():
     assert "Valid output" in cleaned
     assert "> build" not in cleaned
     assert "\u2713" not in cleaned
+
+
+def test_assign_agents_complexity_routing():
+    config = MagicMock(
+        model_mode="random",
+        claude_only=False,
+        gemini_only=False,
+        opencode_only=False,
+    )
+    ai = AIRunner(MagicMock(), MagicMock(), config)
+
+    task_1 = {"complexity": 1}
+    task_2 = {"complexity": 2}
+    task_3 = {"complexity": 3}
+    task_default = {}
+
+    coder1, rev1 = ai.assign_agents(task_1)
+    coder2, rev2 = ai.assign_agents(task_2)
+    coder3, rev3 = ai.assign_agents(task_3)
+    coder_def, rev_def = ai.assign_agents(task_default)
+
+    assert coder1 == "opencode", f"complexity 1 should use opencode/kimi, got {coder1}"
+    assert rev1 == "gemini", f"complexity 1 should use gemini for reviewer, got {rev1}"
+
+    assert coder2 == "gemini", f"complexity 2 should use gemini, got {coder2}"
+    assert rev2 == "claude", f"complexity 2 should use claude for reviewer, got {rev2}"
+
+    assert coder3 == "claude", f"complexity 3 should use claude, got {coder3}"
+    assert rev3 == "gemini", f"complexity 3 should use gemini for reviewer, got {rev3}"
+
+    assert coder_def == "opencode", f"default complexity should use opencode, got {coder_def}"
+
+
+def test_run_reviewer_claude_removes_claudecode():
+    runner = MagicMock()
+    runner.run.return_value.stdout = "Review output"
+    config = MagicMock(opencode_model="kimi")
+    ai = AIRunner(runner, MagicMock(), config)
+
+    with patch.dict(os.environ, {}, clear=True):
+        ai.run_reviewer("claude", "test prompt")
+
+    call_kwargs = runner.run.call_args[1]
+    assert call_kwargs.get("env_removals") == ["CLAUDECODE"]
+
+
+def test_run_test_writer_uses_different_model():
+    runner = MagicMock()
+    runner.run.return_value.stdout = "Tests written"
+    config = MagicMock(opencode_model="kimi")
+    logger = MagicMock()
+    ai = AIRunner(runner, logger, config)
+
+    ai.run_test_writer("test prompt", Path("."))
+
+    call_args = runner.run.call_args[0][0]
+    assert call_args[0] in ("claude", "gemini")


### PR DESCRIPTION
## [M1-10] ai_runner

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement AIRunner: subprocess wrappers for all AI backends (claude, gemini, opencode). Complexity-based model routing. Nested-Claude session detection. Separate test-writer role. See DESIGN.md: AIRunner and lesson #8.

### Acceptance Criteria
['AIRunner(runner: SubprocessRunner, logger: RalphLogger, config: Config) constructor', "_is_nested_claude_session() -> bool returns True if 'CLAUDECODE' in os.environ", 'assign_agents(task: dict) -> tuple[str, str]: returns (coder, reviewer) based on config.model_mode and task complexity; complexity 1 → kimi/gemini-flash, 2 → gemini-pro/claude-sonnet, 3 → claude-opus/gemini-ultra; respects --claude-only/--gemini-only/--opencode-only overrides', 'run_coder(agent: str, prompt: str, cwd: Path) -> bool: invokes the agent subprocess, returns True on success', "run_reviewer(agent: str, prompt: str) -> str: returns reviewer output; if agent=='claude' and _is_nested_claude_session(), logs warning and falls back to gemini", 'run_test_writer(prompt: str, cwd: Path) -> bool: always uses a different model from the coder for the same task (enforced by assign_agents)', "All Claude calls pass env_removals=['CLAUDECODE'] to SubprocessRunner", 'Tests mock SubprocessRunner; verify nested-Claude fallback triggers; verify complexity routing for each tier; verify CLAUDECODE is removed from env on Claude calls']

---
*Ralph Loop — multi-agent AI pair programming*