### PR TITLE
[M1-13] test_writer

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -919,31 +919,31 @@ class AIRunner:
         """True when ralph is running inside a Claude Code session."""
         return "CLAUDECODE" in os.environ
 
-    def assign_agents(self, task: dict) -> tuple[str, str]:
-        """Returns (coder, reviewer) based on complexity and config."""
+    def assign_agents(self, task: dict) -> tuple[str, str, str]:
+        """Returns (coder, reviewer, test_writer) based on complexity and config."""
         if self.config.claude_only:
-            return "claude", "claude"
+            return "claude", "claude", "gemini"
         if self.config.gemini_only:
-            return "gemini", "gemini"
+            return "gemini", "claude", "opencode"
         if self.config.opencode_only:
-            return "opencode", "opencode"
+            return "opencode", "claude", "gemini"
 
         complexity = task.get("complexity") or 1
         # Complexity mapping from DESIGN.md
         if self.config.model_mode == "claude":
-            return "claude", "claude"
+            return "claude", "gemini", "opencode"
         if self.config.model_mode == "gemini":
-            return "gemini", "gemini"
+            return "gemini", "opencode", "claude"
         if self.config.model_mode == "opencode":
-            return "opencode", "opencode"
+            return "opencode", "gemini", "claude"
 
         # Default random-ish assignment based on complexity
         if complexity == 1:
-            return "opencode", "gemini"
+            return "opencode", "gemini", "claude"
         elif complexity == 2:
-            return "gemini", "claude"
+            return "gemini", "claude", "opencode"
         else:
-            return "claude", "gemini"
+            return "claude", "gemini", "opencode"
 
     def _clean_output(self, text: str) -> str:
         """Strips ANSI escape codes and opencode internal UI lines."""
@@ -1036,9 +1036,10 @@ class AIRunner:
             self.logger.error(f"Reviewer {agent} failed.")
             return ""
 
-    def run_test_writer(self, prompt: str, cwd: Path) -> bool:
+    def run_test_writer(self, prompt: str, cwd: Path, agent: str | None = None) -> bool:
         """Test writer always uses a different model from coder."""
-        agent = "gemini" if self._is_nested_claude_session() else "claude"
+        if agent is None:
+            agent = "gemini" if self._is_nested_claude_session() else "claude"
         return self.run_coder(agent, prompt, cwd)
 
     def run_decompose(self, task: dict) -> list[dict]:
@@ -1095,7 +1096,7 @@ class PreCommitGate:
 
             if rounds_used < self.config.max_precommit_rounds:
                 prompt = PromptBuilder.precommit_fix_prompt(task, result.stdout)
-                coder, _ = self.ai_runner.assign_agents(task)
+                coder, _, _ = self.ai_runner.assign_agents(task)
                 self.ai_runner.run_coder(coder, prompt, branch_dir)
             else:
                 self.logger.error("Pre-commit still failing after max rounds.")
@@ -1152,12 +1153,77 @@ class TestRunner:
 
             if rounds_used < self.config.max_test_fix_rounds:
                 prompt = PromptBuilder.test_fix_prompt(task, failure_output)
-                coder, _ = self.ai_runner.assign_agents(task)
+                coder, _, _ = self.ai_runner.assign_agents(task)
                 self.ai_runner.run_coder(coder, prompt, self.config.repo_dir)
             else:
                 self.logger.error("Quality checks still failing after max rounds.")
 
         return TestResult(passed=False, rounds_used=rounds_used)
+
+
+class RalphTestWriter:
+    """
+    TDD mode component that invokes a separate AI agent to write failing tests
+    before the coder starts. The test writer must be a different model from
+    the eventual coder.
+    """
+
+    def __init__(
+        self,
+        ai_runner: "AIRunner",
+        runner: SubprocessRunner,
+        logger: RalphLogger,
+    ):
+        self.ai_runner = ai_runner
+        self.runner = runner
+        self.logger = logger
+
+    def write_tests(self, task: dict, branch_dir: Path) -> Path:
+        """
+        Invokes test-writer agent, commits failing tests to branch.
+        Returns Path to the committed test file.
+        """
+        _, _, test_writer = self.ai_runner.assign_agents(task)
+        prompt = PromptBuilder.test_writer_prompt(task)
+        self.ai_runner.run_test_writer(prompt, branch_dir, agent=test_writer)
+
+        test_file_path = self._discover_test_file(task, branch_dir)
+
+        self.runner.run(
+            ["git", "add", str(test_file_path)],
+            cwd=branch_dir,
+            check=True,
+        )
+        commit_msg = f"[{task['id']}] {task['title']}: add failing tests"
+        self.runner.run(
+            ["git", "commit", "-m", commit_msg],
+            cwd=branch_dir,
+            check=True,
+        )
+
+        return test_file_path
+
+    def _discover_test_file(self, task: dict, branch_dir: Path) -> Path:
+        """Looks in tests/ directory for files matching test_{task_title}*.py."""
+        task_title = task.get("title", "")
+        sanitised = re.sub(r"[^a-zA-Z0-9]", "_", task_title.lower())
+        pattern = f"test_{sanitised}*.py"
+
+        tests_dir = branch_dir / "tests"
+        if not tests_dir.exists():
+            raise RalphError(f"tests/ directory not found in {branch_dir}")
+
+        matching = list(tests_dir.glob(pattern))
+        if not matching:
+            raise RalphError(f"No test file found matching pattern '{pattern}' in tests/ directory")
+
+        if len(matching) > 1:
+            self.logger.warn(f"Multiple test files match '{pattern}', using first: {matching[0]}")
+
+        return matching[0]
+
+
+TestWriter = RalphTestWriter
 
 
 def main() -> int:

--- a/tests/test_ai_runner.py
+++ b/tests/test_ai_runner.py
@@ -21,11 +21,21 @@ def test_is_nested_claude_session():
 def test_assign_agents_overrides():
     config = MagicMock(claude_only=True, gemini_only=False, opencode_only=False)
     ai = AIRunner(MagicMock(), MagicMock(), config)
-    assert ai.assign_agents({}) == ("claude", "claude")
+    coder, rev, tw = ai.assign_agents({})
+    assert (coder, rev) == ("claude", "claude")
+    assert tw == "gemini"
 
     config.claude_only = False
     config.gemini_only = True
-    assert ai.assign_agents({}) == ("gemini", "gemini")
+    coder, rev, tw = ai.assign_agents({})
+    assert (coder, rev) == ("gemini", "claude")
+    assert tw == "opencode"
+
+    config.gemini_only = False
+    config.opencode_only = True
+    coder, rev, tw = ai.assign_agents({})
+    assert (coder, rev) == ("opencode", "claude")
+    assert tw == "gemini"
 
 
 def test_run_coder_claude():
@@ -83,21 +93,25 @@ def test_assign_agents_complexity_routing():
     task_3 = {"complexity": 3}
     task_default = {}
 
-    coder1, rev1 = ai.assign_agents(task_1)
-    coder2, rev2 = ai.assign_agents(task_2)
-    coder3, rev3 = ai.assign_agents(task_3)
-    coder_def, rev_def = ai.assign_agents(task_default)
+    coder1, rev1, tw1 = ai.assign_agents(task_1)
+    coder2, rev2, tw2 = ai.assign_agents(task_2)
+    coder3, rev3, tw3 = ai.assign_agents(task_3)
+    coder_def, rev_def, tw_def = ai.assign_agents(task_default)
 
     assert coder1 == "opencode", f"complexity 1 should use opencode/kimi, got {coder1}"
     assert rev1 == "gemini", f"complexity 1 should use gemini for reviewer, got {rev1}"
+    assert tw1 != coder1, "test_writer must be different from coder"
 
     assert coder2 == "gemini", f"complexity 2 should use gemini, got {coder2}"
     assert rev2 == "claude", f"complexity 2 should use claude for reviewer, got {rev2}"
+    assert tw2 != coder2, "test_writer must be different from coder"
 
     assert coder3 == "claude", f"complexity 3 should use claude, got {coder3}"
     assert rev3 == "gemini", f"complexity 3 should use gemini for reviewer, got {rev3}"
+    assert tw3 != coder3, "test_writer must be different from coder"
 
     assert coder_def == "opencode", f"default complexity should use opencode, got {coder_def}"
+    assert tw_def != coder_def, "test_writer must be different from coder"
 
 
 def test_run_reviewer_claude_removes_claudecode():

--- a/tests/test_precommit_gate.py
+++ b/tests/test_precommit_gate.py
@@ -29,7 +29,7 @@ def test_precommit_gate_fail_then_success():
     ]
 
     ai_runner = MagicMock()
-    ai_runner.assign_agents.return_value = ("coder", "reviewer")
+    ai_runner.assign_agents.return_value = ("coder", "reviewer", "test_writer")
 
     config = MagicMock(max_precommit_rounds=2)
     gate = PreCommitGate(runner, ai_runner, MagicMock(), config)
@@ -45,7 +45,7 @@ def test_precommit_gate_max_rounds_reached():
     runner.run.return_value.returncode = 1
 
     ai_runner = MagicMock()
-    ai_runner.assign_agents.return_value = ("coder", "reviewer")
+    ai_runner.assign_agents.return_value = ("coder", "reviewer", "test_writer")
 
     config = MagicMock(max_precommit_rounds=2)
     gate = PreCommitGate(runner, ai_runner, MagicMock(), config)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -51,7 +51,7 @@ def test_test_runner_fail_then_success():
     ]
 
     ai_runner = MagicMock()
-    ai_runner.assign_agents.return_value = ("coder", "reviewer")
+    ai_runner.assign_agents.return_value = ("coder", "reviewer", "test_writer")
 
     task_tracker = MagicMock()
     task_tracker.get_quality_checks.return_value = ["pytest tests/ -v"]
@@ -72,7 +72,7 @@ def test_test_runner_max_rounds_reached():
     runner.run.return_value.returncode = 1
 
     ai_runner = MagicMock()
-    ai_runner.assign_agents.return_value = ("coder", "reviewer")
+    ai_runner.assign_agents.return_value = ("coder", "reviewer", "test_writer")
 
     task_tracker = MagicMock()
     task_tracker.get_quality_checks.return_value = ["pytest tests/ -v"]
@@ -93,7 +93,7 @@ def test_test_runner_fix_loop_fires_on_failure():
     runner.run.return_value.returncode = 1
 
     ai_runner = MagicMock()
-    ai_runner.assign_agents.return_value = ("claude", "reviewer")
+    ai_runner.assign_agents.return_value = ("claude", "reviewer", "test_writer")
 
     task_tracker = MagicMock()
     task_tracker.get_quality_checks.return_value = ["ruff check ."]

--- a/tests/test_test_writer.py
+++ b/tests/test_test_writer.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ralph import RalphError, RalphTestWriter
+
+
+def test_test_writer_constructor():
+    """RalphTestWriter accepts ai_runner, runner, and logger in constructor."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+
+    assert tw.ai_runner is ai_runner
+    assert tw.runner is runner
+    assert tw.logger is logger
+
+
+def test_write_tests_invokes_test_writer():
+    """write_tests invokes AIRunner.run_test_writer with test_writer_prompt."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+    ai_runner.assign_agents.return_value = ("opencode", "gemini", "claude")
+
+    task = {"id": "TASK-01", "title": "my task", "description": "desc", "acceptance_criteria": []}
+    branch_dir = Path("/fake/repo")
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+    with patch.object(tw, "_discover_test_file", return_value=Path("tests/test_my_task.py")):
+        tw.write_tests(task, branch_dir)
+
+    ai_runner.assign_agents.assert_called_once_with(task)
+    ai_runner.run_test_writer.assert_called_once()
+
+
+def test_write_tests_commits_test_file():
+    """write_tests commits the test file to the current branch."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+    ai_runner.assign_agents.return_value = ("opencode", "gemini", "claude")
+
+    task = {
+        "id": "TASK-01",
+        "title": "my task",
+        "description": "desc",
+        "acceptance_criteria": ["AC1"],
+    }
+    branch_dir = Path("/fake/repo")
+
+    test_file_path = Path("tests/test_my_task.py")
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+    with patch.object(tw, "_discover_test_file", return_value=test_file_path):
+        tw.write_tests(task, branch_dir)
+
+    calls = runner.run.call_args_list
+    add_call = [c for c in calls if "git" in c[0][0] and "add" in c[0][0]][0]
+    assert str(test_file_path) in add_call[0][0]
+
+    commit_call = [c for c in calls if "git" in c[0][0] and "commit" in c[0][0]][0]
+    assert "[TASK-01] my task: add failing tests" in commit_call[0][0]
+
+
+def test_write_tests_returns_test_file_path():
+    """write_tests returns the Path to the committed test file."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+    ai_runner.assign_agents.return_value = ("opencode", "gemini", "claude")
+
+    task = {"id": "TASK-02", "title": "foo bar", "description": "desc", "acceptance_criteria": []}
+    branch_dir = Path("/fake/repo")
+
+    test_file_path = Path("tests/test_foo_bar.py")
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+    with patch.object(tw, "_discover_test_file", return_value=test_file_path):
+        result = tw.write_tests(task, branch_dir)
+
+    assert result == test_file_path
+
+
+def test_discover_test_file_pattern(tmp_path):
+    """_discover_test_file looks for test_{task_title}*.py in tests/."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+
+    task = {"title": "Implement Feature X"}
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_file = tests_dir / "test_implement_feature_x.py"
+    test_file.write_text("# test")
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+    result = tw._discover_test_file(task, tmp_path)
+
+    assert result.name == "test_implement_feature_x.py"
+
+
+def test_discover_test_file_not_found(tmp_path):
+    """_discover_test_file raises error when no test file found."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+
+    task = {"title": "Some Task"}
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+
+    with pytest.raises(RalphError, match="No test file found"):
+        tw._discover_test_file(task, tmp_path)
+
+
+def test_discover_test_file_no_tests_dir(tmp_path):
+    """_discover_test_file raises error when tests/ directory doesn't exist."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+
+    task = {"title": "Some Task"}
+    branch_dir = tmp_path
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+
+    with pytest.raises(RalphError, match="tests/ directory not found"):
+        tw._discover_test_file(task, branch_dir)
+
+
+def test_write_tests_uses_test_writer_from_assign_agents():
+    """The test writer model comes from assign_agents (different from coder)."""
+    ai_runner = MagicMock()
+    runner = MagicMock()
+    logger = MagicMock()
+    ai_runner.assign_agents.return_value = ("claude", "gemini", "opencode")
+
+    task = {"id": "TEST-01", "title": "test", "description": "desc", "acceptance_criteria": []}
+    branch_dir = Path("/fake/repo")
+
+    tw = RalphTestWriter(ai_runner, runner, logger)
+    with patch.object(tw, "_discover_test_file", return_value=Path("tests/test_x.py")):
+        tw.write_tests(task, branch_dir)
+
+    ai_runner.run_test_writer.assert_called_once()
+    args, kwargs = ai_runner.run_test_writer.call_args
+    assert kwargs.get("agent") == "opencode"
+
+
+def test_all_three_agents_are_distinct():
+    """assign_agents returns three distinct models."""
+    config = MagicMock(
+        model_mode="random",
+        claude_only=False,
+        gemini_only=False,
+        opencode_only=False,
+    )
+    from ralph import AIRunner
+
+    ai = AIRunner(MagicMock(), MagicMock(), config)
+
+    for complexity in [1, 2, 3]:
+        task = {"complexity": complexity}
+        coder, reviewer, test_writer = ai.assign_agents(task)
+        assert coder != reviewer, f"coder ({coder}) must differ from reviewer ({reviewer})"
+        assert coder != test_writer, f"coder ({coder}) must differ from test_writer ({test_writer})"
+        assert reviewer != test_writer, (
+            f"reviewer ({reviewer}) must differ from test_writer ({test_writer})"
+        )


### PR DESCRIPTION
## [M1-13] test_writer

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement TestWriter: TDD mode component that invokes a separate AI agent to write failing tests before the coder starts. The test writer must be a different model from the eventual coder. See DESIGN.md: TestWriter.

### Acceptance Criteria
['TestWriter(ai_runner: AIRunner, runner: SubprocessRunner, logger: RalphLogger) constructor', 'write_tests(task: dict, branch_dir: Path) -> Path: invokes AIRunner.run_test_writer() with PromptBuilder.test_writer_prompt(task)', 'Discovers the test file written by the agent (looks in tests/ directory for files matching test_{task_title}*.py)', 'Commits the test file to the current branch via SubprocessRunner (git add, git commit)', 'Returns the Path to the committed test file', 'The model used for test writing is always different from the model that will be used for coding the same task (enforced via AIRunner.assign_agents returning distinct test_writer model)', 'Tests mock AIRunner and SubprocessRunner; verify commit is issued; verify path returned']

---
*Ralph Loop — multi-agent AI pair programming*