### PR TITLE
[M1-17] ci_poller_parent

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -1569,6 +1569,164 @@ class TestQualityChecker:
         )
 
 
+class CIPoller:
+    """
+    Polls CI completion using run-ID pinning to avoid stale-data race.
+    On failure: fetches logs, invokes coder fix loop, re-polls.
+    """
+
+    def __init__(
+        self,
+        runner: SubprocessRunner,
+        ai_runner: AIRunner,
+        logger: RalphLogger,
+        config: Config,
+    ):
+        self.runner = runner
+        self.ai_runner = ai_runner
+        self.logger = logger
+        self.config = config
+
+    def _get_latest_run_id(self, branch: str) -> str:
+        """Gets the latest run ID for a branch using gh run list."""
+        result = self.runner.run(
+            [
+                "gh",
+                "run",
+                "list",
+                "--branch",
+                branch,
+                "--json",
+                "databaseId",
+                "--jq",
+                ".[0].databaseId",
+            ],
+            check=True,
+        )
+        run_id = result.stdout.strip()
+        if not run_id:
+            raise CITimeoutError(f"No run found for branch {branch}")
+        return run_id
+
+    def _wait_for_run(self, run_id: str) -> str:
+        """Polls a specific run ID until completion. Returns 'PASSED' or 'FAILED'."""
+        attempts = 0
+        while attempts < CI_POLL_MAX_ATTEMPTS:
+            result = self.runner.run(
+                [
+                    "gh",
+                    "run",
+                    "view",
+                    run_id,
+                    "--json",
+                    "status,conclusion",
+                ],
+                check=True,
+            )
+            data = json.loads(result.stdout)
+            status = data.get("status", "")
+            conclusion = data.get("conclusion")
+
+            if status in CI_PENDING_STATES:
+                self.logger.info(f"Run {run_id} status: {status} (attempt {attempts + 1})")
+                time.sleep(CI_POLL_INTERVAL_SECS)
+                attempts += 1
+                continue
+
+            if conclusion in CI_FAILURE_STATES:
+                return "FAILED"
+
+            if conclusion == "success":
+                return "PASSED"
+
+            return conclusion or "UNKNOWN"
+
+        raise CITimeoutError(
+            f"CI run {run_id} did not complete after "
+            f"{CI_POLL_MAX_ATTEMPTS * CI_POLL_INTERVAL_SECS // 60} minutes"
+        )
+
+    def _wait_for_new_run(self, branch: str, prev_run_id: str, timeout: int = 180) -> str:
+        """Polls until a new run ID appears. Returns new run ID or raises CITimeoutError."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                new_run_id = self._get_latest_run_id(branch)
+                if new_run_id != prev_run_id:
+                    self.logger.info(f"New run detected: {new_run_id}")
+                    return new_run_id
+            except Exception:
+                pass
+
+            self.logger.info(f"Waiting for new run (current: {prev_run_id})...")
+            time.sleep(10)
+
+        raise CITimeoutError(f"No new run appeared for branch {branch} after {timeout}s")
+
+    def wait_for_completion(self, pr_number: int, branch: str) -> CIResult:
+        """Waits for CI to complete using run-ID pinning. Returns CIResult."""
+        self.logger.info(f"Waiting for CI on PR #{pr_number} (branch: {branch})")
+
+        run_id = self._get_latest_run_id(branch)
+        self.logger.info(f"Found run ID: {run_id}")
+
+        conclusion = self._wait_for_run(run_id)
+
+        if conclusion == "PASSED":
+            self.logger.info("CI passed")
+            return CIResult(passed=True, rounds_used=1)
+
+        self.logger.error(f"CI failed with conclusion: {conclusion}")
+        return CIResult(passed=False, rounds_used=1)
+
+    def wait_and_fix(self, task: dict, pr_number: int, branch: str, prd: dict) -> CIResult:
+        """Waits for CI, on failure invokes coder fix loop, re-polls."""
+        rounds_used = 0
+
+        while rounds_used < self.config.max_ci_fix_rounds:
+            result = self.wait_for_completion(pr_number, branch)
+
+            if result.passed:
+                return CIResult(passed=True, rounds_used=rounds_used)
+
+            rounds_used += 1
+            self.logger.warn(f"CI failed (round {rounds_used}/{self.config.max_ci_fix_rounds})")
+
+            if rounds_used >= self.config.max_ci_fix_rounds:
+                break
+
+            self.logger.info("Fetching CI logs and invoking coder fix loop...")
+
+            log_result = self.runner.run(
+                ["gh", "run", "view", "--log-failed"],
+                check=False,
+            )
+            failure_log = log_result.stdout.splitlines()[-150:]
+            failure_log_text = "\n".join(failure_log)
+
+            prompt = PromptBuilder.ci_fix_prompt(task, failure_log_text)
+            coder, _, _ = self.ai_runner.assign_agents(task)
+            success = self.ai_runner.run_coder(coder, prompt, self.config.repo_dir)
+
+            if not success:
+                self.logger.error("Coder fix loop failed")
+                raise CIFailedFatal(f"Coder failed on round {rounds_used}")
+
+            self.logger.info("Pushing fix and waiting for new run...")
+
+            branch_manager = BranchManager(self.config.repo_dir, self.runner, self.logger)
+            branch_manager.push_branch(branch)
+
+            new_run_id = self._wait_for_new_run(branch, "", timeout=180)
+            conclusion = self._wait_for_run(new_run_id)
+
+            if conclusion == "PASSED":
+                return CIResult(passed=True, rounds_used=rounds_used)
+
+        self.logger.error(f"CI still failing after {rounds_used} fix rounds")
+        raise CIFailedFatal(f"CI still failing after {rounds_used} fix rounds")
+
+
 def main() -> int:
     print("ralph.py — skeleton implemented. See roadmap.md.")
     return 0

--- a/tests/test_ci_poller.py
+++ b/tests/test_ci_poller.py
@@ -1,0 +1,182 @@
+"""Tests for CIPoller."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import ralph
+from ralph import (
+    AIRunner,
+    CIFailedFatal,
+    CIPoller,
+    CITimeoutError,
+    Config,
+    RalphLogger,
+    SubprocessRunner,
+)
+
+
+@pytest.fixture
+def mock_runner():
+    return MagicMock(spec=SubprocessRunner)
+
+
+@pytest.fixture
+def mock_ai_runner():
+    return MagicMock(spec=AIRunner)
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock(spec=RalphLogger)
+
+
+@pytest.fixture
+def config(tmp_path):
+    return Config(
+        max_iterations=10,
+        skip_review=False,
+        tdd_mode=False,
+        model_mode="random",
+        opencode_model="opencode/kimi-k2.5",
+        resume=False,
+        repo_dir=tmp_path,
+        log_file=tmp_path / "test.log",
+        max_precommit_rounds=2,
+        max_review_rounds=2,
+        max_ci_fix_rounds=2,
+        max_test_fix_rounds=2,
+        max_test_write_rounds=2,
+        force_task_id=None,
+        deep_review_check=False,
+    )
+
+
+@pytest.fixture
+def ci_poller(mock_runner, mock_ai_runner, mock_logger, config):
+    return CIPoller(mock_runner, mock_ai_runner, mock_logger, config)
+
+
+class TestGetLatestRunId:
+    def test_success(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(stdout="12345")
+
+        result = ci_poller._get_latest_run_id("ralph/test-branch")
+
+        assert result == "12345"
+        mock_runner.run.assert_called_once()
+
+    def test_empty_raises_timeout(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(stdout="")
+
+        with pytest.raises(CITimeoutError, match="No run found"):
+            ci_poller._get_latest_run_id("ralph/test-branch")
+
+
+class TestWaitForRun:
+    def test_pending_then_success(self, ci_poller, mock_runner):
+        with patch.object(ralph, "CI_POLL_MAX_ATTEMPTS", 2):
+            with patch.object(ralph, "CI_POLL_INTERVAL_SECS", 0):
+                mock_runner.run.side_effect = [
+                    MagicMock(stdout=json.dumps({"status": "IN_PROGRESS", "conclusion": None})),
+                    MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+                ]
+
+                result = ci_poller._wait_for_run("12345")
+
+                assert result == "PASSED"
+
+    def test_failure(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(
+            stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})
+        )
+
+        result = ci_poller._wait_for_run("12345")
+
+        assert result == "failure"
+
+    def test_timeout(self, ci_poller, mock_runner):
+        with patch.object(ralph, "CI_POLL_MAX_ATTEMPTS", 1):
+            with patch.object(ralph, "CI_POLL_INTERVAL_SECS", 0):
+                mock_runner.run.return_value = MagicMock(
+                    stdout=json.dumps({"status": "IN_PROGRESS", "conclusion": None})
+                )
+
+                with pytest.raises(CITimeoutError, match="did not complete"):
+                    ci_poller._wait_for_run("12345")
+
+
+class TestWaitForNewRun:
+    def test_new_run_appears(self, ci_poller, mock_runner):
+        call_count = [0]
+        original_time = ralph.time.time
+
+        def fake_time():
+            call_count[0] += 1
+            return call_count[0] * 5
+
+        ralph.time.time = fake_time
+
+        try:
+            mock_runner.run.side_effect = [
+                MagicMock(stdout="12345"),
+                MagicMock(stdout="67890"),
+            ]
+
+            result = ci_poller._wait_for_new_run("ralph/test", "12345", timeout=20)
+
+            assert result == "67890"
+        finally:
+            ralph.time.time = original_time
+
+
+class TestWaitForCompletion:
+    def test_passed(self, ci_poller, mock_runner):
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+        ]
+
+        result = ci_poller.wait_for_completion(42, "ralph/test-branch")
+
+        assert result.passed is True
+        assert result.rounds_used == 1
+
+    def test_failed(self, ci_poller, mock_runner):
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})),
+        ]
+
+        result = ci_poller.wait_for_completion(42, "ralph/test-branch")
+
+        assert result.passed is False
+        assert result.rounds_used == 1
+
+
+class TestWaitAndFix:
+    def test_first_try_passed(self, ci_poller, mock_runner):
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+        ]
+
+        task = {"id": "M1-17a", "title": "ci_poller_polling"}
+        result = ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})
+
+        assert result.passed is True
+
+    def test_coder_fail_raises(self, ci_poller, mock_runner, mock_ai_runner):
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})),
+            MagicMock(stdout="log"),
+        ]
+        mock_ai_runner.assign_agents.return_value = ("claude", "gemini", "opencode")
+        mock_ai_runner.run_coder.return_value = False
+
+        task = {"id": "M1-17a", "title": "ci_poller_polling"}
+
+        with pytest.raises(CIFailedFatal, match="Coder failed"):
+            ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})


### PR DESCRIPTION
## [M1-17] ci_poller_parent

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Parent task — decomposed into M1-17a and M1-17b.

### Acceptance Criteria
[]

---
*Ralph Loop — multi-agent AI pair programming*