### PR TITLE
[M1-17b] ci_poller_fix_loop

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -1690,7 +1690,6 @@ class CIPoller:
             return CIResult(passed=False, rounds_used=0)
 
         self.logger.info(f"Found run ID: {run_id}")
-        self.logger.info(f"Found run ID: {run_id}")
 
         conclusion = self._wait_for_run(run_id)
 
@@ -1701,15 +1700,54 @@ class CIPoller:
         self.logger.error(f"CI failed with conclusion: {conclusion}")
         return CIResult(passed=False, rounds_used=1)
 
+    def _check_required_failures(self, pr_number: int) -> tuple[bool, list[str]]:
+        """Checks required CI checks for failures.
+
+        Filters to only required=true checks. Optional check failures log warning only.
+        Returns (has_required_failure, list of failing required check names).
+        On any error fetching checks, returns (False, []) — fail-open to avoid blocking.
+        """
+        try:
+            pr_manager = PRManager(self.runner, self.logger)
+            checks = pr_manager.get_checks(pr_number)
+        except Exception as exc:
+            self.logger.warn(f"Could not fetch PR checks (skipping required-check filter): {exc}")
+            return False, []
+
+        required_failures = []
+        optional_failures = []
+
+        for check in checks:
+            conclusion = check.get("conclusion", "")
+            if conclusion and conclusion.upper() in ("FAILURE", "ERROR"):
+                if check.get("required", True):
+                    required_failures.append(check.get("name", "unknown"))
+                else:
+                    optional_failures.append(check.get("name", "unknown"))
+
+        for name in optional_failures:
+            self.logger.warn(f"Optional check failed (ignored): {name}")
+
+        return bool(required_failures), required_failures
+
     def wait_and_fix(self, task: dict, pr_number: int, branch: str, prd: dict) -> CIResult:
-        """Waits for CI, on failure invokes coder fix loop, re-polls."""
+        """Waits for CI, on failure invokes coder fix loop, re-polls.
+
+        Filters CI checks to only block on required=true checks.
+        Optional failing checks log warning only.
+        """
         rounds_used = 0
 
         while rounds_used < self.config.max_ci_fix_rounds:
             result = self.wait_for_completion(pr_number, branch)
 
             if result.passed:
-                return CIResult(passed=True, rounds_used=rounds_used)
+                has_required_failure, failing_required = self._check_required_failures(pr_number)
+                if not has_required_failure:
+                    return CIResult(passed=True, rounds_used=rounds_used)
+                self.logger.warn(
+                    f"CI run passed but required checks still failing: {failing_required}"
+                )
 
             rounds_used += 1
             self.logger.warn(f"CI failed (round {rounds_used}/{self.config.max_ci_fix_rounds})")
@@ -1736,14 +1774,15 @@ class CIPoller:
 
             self.logger.info("Pushing fix and waiting for new run...")
 
+            try:
+                current_run_id = self._get_latest_run_id(branch)
+            except CITimeoutError:
+                current_run_id = ""
+
             branch_manager = BranchManager(self.config.repo_dir, self.runner, self.logger)
             branch_manager.push_branch(branch)
 
-            new_run_id = self._wait_for_new_run(branch, "", timeout=180)
-            conclusion = self._wait_for_run(new_run_id)
-
-            if conclusion == "PASSED":
-                return CIResult(passed=True, rounds_used=rounds_used)
+            self._wait_for_new_run(branch, current_run_id, timeout=180)
 
         self.logger.error(f"CI still failing after {rounds_used} fix rounds")
         raise CIFailedFatal(f"CI still failing after {rounds_used} fix rounds")

--- a/tests/test_ci_poller.py
+++ b/tests/test_ci_poller.py
@@ -155,11 +155,55 @@ class TestWaitForCompletion:
         assert result.rounds_used == 1
 
 
+class TestCheckRequiredFailures:
+    def test_required_check_fails_blocks(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {"name": "build", "conclusion": "failure", "required": True},
+                    {"name": "lint", "conclusion": "failure", "required": True},
+                    {"name": "test-optional", "conclusion": "failure", "required": False},
+                ]
+            )
+        )
+
+        has_required, failures = ci_poller._check_required_failures(42)
+
+        assert has_required is True
+        assert "build" in failures
+        assert "lint" in failures
+        assert "test-optional" not in failures
+
+    def test_only_optional_fails_does_not_block(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {"name": "lint", "conclusion": "success", "required": True},
+                    {"name": "test-optional", "conclusion": "failure", "required": False},
+                ]
+            )
+        )
+
+        has_required, failures = ci_poller._check_required_failures(42)
+
+        assert has_required is False
+        assert failures == []
+
+    def test_no_checks_returns_pass(self, ci_poller, mock_runner):
+        mock_runner.run.return_value = MagicMock(stdout=json.dumps([]))
+
+        has_required, failures = ci_poller._check_required_failures(42)
+
+        assert has_required is False
+        assert failures == []
+
+
 class TestWaitAndFix:
     def test_first_try_passed(self, ci_poller, mock_runner):
         mock_runner.run.side_effect = [
             MagicMock(stdout="12345"),
             MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+            MagicMock(stdout=json.dumps([])),  # _check_required_failures -> no checks
         ]
 
         task = {"id": "M1-17a", "title": "ci_poller_polling"}
@@ -167,11 +211,27 @@ class TestWaitAndFix:
 
         assert result.passed is True
 
+    def test_optional_check_failure_does_not_block(self, ci_poller, mock_runner):
+        """CI passes and only optional checks fail — returns success without invoking fix."""
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+            MagicMock(
+                stdout=json.dumps([{"name": "lint", "conclusion": "failure", "required": False}])
+            ),
+        ]
+
+        task = {"id": "M1-17b", "title": "ci_poller_fix_loop"}
+        result = ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})
+
+        assert result.passed is True
+
     def test_coder_fail_raises(self, ci_poller, mock_runner, mock_ai_runner):
+        # CI failure path does NOT call _check_required_failures
         mock_runner.run.side_effect = [
             MagicMock(stdout="12345"),
             MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})),
-            MagicMock(stdout="log"),
+            MagicMock(stdout="failure log"),  # gh run view --log-failed
         ]
         mock_ai_runner.assign_agents.return_value = ("claude", "gemini", "opencode")
         mock_ai_runner.run_coder.return_value = False
@@ -179,4 +239,91 @@ class TestWaitAndFix:
         task = {"id": "M1-17a", "title": "ci_poller_polling"}
 
         with pytest.raises(CIFailedFatal, match="Coder failed"):
+            ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})
+
+
+class TestWaitForNewRunAfterPush:
+    def test_wait_for_new_run_called_after_push(self, tmp_path):
+        """_wait_for_new_run is called after push_branch with the pre-push run ID."""
+        config = Config(
+            max_iterations=10,
+            skip_review=False,
+            tdd_mode=False,
+            model_mode="random",
+            opencode_model="opencode/kimi-k2.5",
+            resume=False,
+            repo_dir=tmp_path,
+            log_file=tmp_path / "test.log",
+            max_precommit_rounds=2,
+            max_review_rounds=2,
+            max_ci_fix_rounds=2,
+            max_test_fix_rounds=2,
+            max_test_write_rounds=2,
+            force_task_id=None,
+            deep_review_check=False,
+        )
+        mock_runner = MagicMock(spec=SubprocessRunner)
+        mock_ai_runner = MagicMock(spec=AIRunner)
+        mock_logger = MagicMock(spec=RalphLogger)
+        ci_poller = CIPoller(mock_runner, mock_ai_runner, mock_logger, config)
+
+        ci_poller._wait_for_new_run = MagicMock(return_value="67890")
+
+        mock_runner.run.side_effect = [
+            # Round 1: CI fails (no _check_required_failures call on CI failure)
+            MagicMock(stdout="12345"),  # get_run_id in wait_for_completion
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})),
+            MagicMock(stdout="failure output"),  # gh run view --log-failed
+            MagicMock(stdout="12345"),  # get_run_id before push (current_run_id)
+            # push_branch: verify_ssh_remote + git push
+            MagicMock(stdout="git@github.com:org/repo.git"),
+            MagicMock(stdout=""),
+            # Round 2: CI passes — _check_required_failures IS called now
+            MagicMock(stdout="67890"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "success"})),
+            MagicMock(stdout=json.dumps([])),  # _check_required_failures -> no failures
+        ]
+        mock_ai_runner.assign_agents.return_value = ("claude", "gemini", "opencode")
+        mock_ai_runner.run_coder.return_value = True
+
+        task = {"id": "M1-17b", "title": "ci_poller_fix_loop"}
+        result = ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})
+
+        assert result.passed is True
+        ci_poller._wait_for_new_run.assert_called_once_with(
+            "ralph/test-branch", "12345", timeout=180
+        )
+
+    def test_max_rounds_raises_cifailedfatal(self, tmp_path):
+        config = Config(
+            max_iterations=10,
+            skip_review=False,
+            tdd_mode=False,
+            model_mode="random",
+            opencode_model="opencode/kimi-k2.5",
+            resume=False,
+            repo_dir=tmp_path,
+            log_file=tmp_path / "test.log",
+            max_precommit_rounds=2,
+            max_review_rounds=2,
+            max_ci_fix_rounds=1,
+            max_test_fix_rounds=2,
+            max_test_write_rounds=2,
+            force_task_id=None,
+            deep_review_check=False,
+        )
+        mock_runner = MagicMock(spec=SubprocessRunner)
+        mock_ai_runner = MagicMock(spec=AIRunner)
+        mock_logger = MagicMock(spec=RalphLogger)
+        ci_poller = CIPoller(mock_runner, mock_ai_runner, mock_logger, config)
+
+        # CI failure path: _check_required_failures not called, only 2 mocks needed
+        mock_runner.run.side_effect = [
+            MagicMock(stdout="12345"),
+            MagicMock(stdout=json.dumps({"status": "COMPLETED", "conclusion": "failure"})),
+        ]
+
+        task = {"id": "M1-17a", "title": "ci_poller_polling"}
+
+        with pytest.raises(CIFailedFatal, match="CI still failing"):
             ci_poller.wait_and_fix(task, 42, "ralph/test-branch", {})


### PR DESCRIPTION
## [M1-17b] ci_poller_fix_loop

**Epic:** M1
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement CIPoller's fix loop: on CI failure, fetches logs, invokes coder, pushes fix, waits for new run ID before re-polling. Handles required-vs-optional check filtering. See DESIGN.md: CIPoller.

### Acceptance Criteria
['wait_and_fix(task: dict, pr_number: int, branch: str, prd: dict) -> CIResult builds on wait_for_completion', "On FAILED: fetches last 150 lines of 'gh run view --log-failed' output", 'Invokes AIRunner.run_coder() with PromptBuilder.ci_fix_prompt(task, failure_log)', 'Pushes fix via SubprocessRunner, then calls _wait_for_new_run() before re-polling — never polls immediately after push', 'Filters CI checks to only block on required=true checks (optional failing checks log warning only)', 'After config.max_ci_fix_rounds still failing: raises CIFailedFatal', 'Returns CIResult(passed=True, rounds_used=N) on success', "Tests mock SubprocessRunner and AIRunner; verify _wait_for_new_run called after push; verify optional checks don't block; verify CIFailedFatal raised after max rounds"]

---
*Ralph Loop — multi-agent AI pair programming*