### PR TITLE
[M3-02] prd_validator

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -115,6 +115,43 @@ class PlanInvalidError(RalphError):
     pass
 
 
+class PrdValidator:
+    """Shared validation layer for prd.json tasks.
+
+    Enforces 4 rules:
+    1. description >= 100 chars
+    2. At least one AC references a file path pattern
+    3. No credential strings in ralph-owned tasks
+    4. All depends_on IDs exist in all_task_ids
+    """
+
+    FILE_PATH_PATTERN = re.compile(r"[\w/]+\.py|tests/")
+    CREDENTIAL_PATTERN = re.compile(r"(?i)(password|secret|api.?key|token)")
+
+    def validate(self, task: dict, all_task_ids: set[str]) -> None:
+        task_id = task.get("id", "UNKNOWN")
+
+        description = task.get("description", "")
+        if len(description) < 100:
+            raise PlanInvalidError(f"{task_id}: description too short (< 100 chars)")
+
+        acs = task.get("acceptance_criteria", [])
+        has_file_ref = any(self.FILE_PATH_PATTERN.search(str(ac)) for ac in acs)
+        if not has_file_ref:
+            raise PlanInvalidError(
+                f"{task_id}: no acceptance criterion contains a file path pattern"
+            )
+
+        owner = task.get("owner", "")
+        if owner == "ralph":
+            if self.CREDENTIAL_PATTERN.search(description):
+                raise PlanInvalidError(f"{task_id}: description contains credential string")
+
+        for dep_id in task.get("depends_on", []):
+            if dep_id not in all_task_ids:
+                raise PlanInvalidError(f"{task_id}: depends_on unknown task '{dep_id}'")
+
+
 class AgentSandboxViolation(RalphError):  # noqa: N818
     """Agent attempted an operation outside its sandbox."""
 
@@ -725,10 +762,17 @@ class PlanChecker:
     Structural validation, complexity inference, and auto-decomposition.
     """
 
-    def __init__(self, task_tracker: TaskTracker, ai_runner, logger: RalphLogger):
+    def __init__(
+        self,
+        task_tracker: TaskTracker,
+        ai_runner,
+        logger: RalphLogger,
+        validator: PrdValidator | None = None,
+    ):
         self.task_tracker = task_tracker
         self.ai_runner = ai_runner
         self.logger = logger
+        self.validator = validator or PrdValidator()
 
     def check_structural(self, prd: dict) -> list[str]:
         """Validates required fields, non-empty ACs, and resolved dependencies."""
@@ -764,6 +808,11 @@ class PlanChecker:
                     errors.append(f"{task_id}: depends_on unknown task '{dep}'")
                 elif dep not in completed_ids:
                     errors.append(f"{task_id}: depends_on incomplete task '{dep}'")
+
+            try:
+                self.validator.validate(task, all_ids)
+            except PlanInvalidError as e:
+                errors.append(str(e))
 
         return errors
 

--- a/tests/test_plan_checker.py
+++ b/tests/test_plan_checker.py
@@ -11,8 +11,9 @@ def test_check_structural_valid():
             {
                 "id": "T1",
                 "title": "T1",
-                "description": "Desc",
-                "acceptance_criteria": ["AC1"],
+                "description": "This is a valid task description that is definitely longer "
+                "than one hundred characters to satisfy the prd validator rule.",
+                "acceptance_criteria": ["Must update tests/test_module.py"],
                 "owner": "ralph",
                 "completed": False,
             }
@@ -47,7 +48,8 @@ def test_check_structural_empty_ac():
             {
                 "id": "T1",
                 "title": "T1",
-                "description": "Desc",
+                "description": "This is a valid task description that is definitely longer "
+                "than one hundred characters to satisfy the prd validator rule.",
                 "acceptance_criteria": [],
                 "owner": "ralph",
                 "completed": False,
@@ -65,8 +67,9 @@ def test_check_structural_unresolved_dep():
             {
                 "id": "T1",
                 "title": "T1",
-                "description": "Desc",
-                "acceptance_criteria": ["AC1"],
+                "description": "This is a valid task description that is definitely longer "
+                "than one hundred characters to satisfy the prd validator rule.",
+                "acceptance_criteria": ["Must update tests/test_module.py"],
                 "owner": "ralph",
                 "completed": False,
                 "depends_on": ["T2"],

--- a/tests/test_prd_validator.py
+++ b/tests/test_prd_validator.py
@@ -1,0 +1,189 @@
+import pytest
+
+from ralph import PlanInvalidError, PrdValidator
+
+
+class TestPrdValidator:
+    def test_validate_rule1_short_description_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "Short",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "description too short" in str(exc_info.value)
+
+    def test_validate_rule2_no_file_path_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely "
+            "longer than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": ["Must work correctly", "No file reference here"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "no acceptance criterion contains a file path pattern" in str(exc_info.value)
+
+    def test_validate_rule3_credential_in_description_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that definitely contains "
+            "a secret key for the API integration and must be 100 chars.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "contains credential string" in str(exc_info.value)
+
+    def test_validate_rule3_credential_password_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that definitely uses "
+            "password authentication for the service and must be 100 chars.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "contains credential string" in str(exc_info.value)
+
+    def test_validate_rule3_credential_token_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that definitely uses "
+            "a token for authentication and must be over 100 chars.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "contains credential string" in str(exc_info.value)
+
+    def test_validate_rule3_credential_api_key_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that definitely uses "
+            "an API key for the integration and must be over 100 chars.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "contains credential string" in str(exc_info.value)
+
+    def test_validate_rule3_human_task_allows_credential(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that definitely uses "
+            "a secret key for the service and must be over 100 chars.",
+            "acceptance_criteria": ["Must configure credentials in tests/test_config.py"],
+            "owner": "human",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        validator.validate(task, all_task_ids)
+
+    def test_validate_rule4_unknown_depends_on_id_fails(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely longer "
+            "than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": ["T2"],
+        }
+        all_task_ids = {"T1"}
+
+        with pytest.raises(PlanInvalidError) as exc_info:
+            validator.validate(task, all_task_ids)
+        assert "depends_on unknown task 'T2'" in str(exc_info.value)
+
+    def test_validate_valid_task_passes(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely "
+            "longer than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": ["Must update tests/test_module.py"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        validator.validate(task, all_task_ids)
+
+    def test_validate_valid_task_with_file_path_pattern_dot_py(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely "
+            "longer than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": ["Update ralph.py to implement feature"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        validator.validate(task, all_task_ids)
+
+    def test_validate_valid_task_with_tests_directory(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely "
+            "longer than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": ["Add tests for the new feature in tests/"],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        validator.validate(task, all_task_ids)
+
+    def test_validate_valid_task_with_multiple_acs(self):
+        validator = PrdValidator()
+        task = {
+            "id": "T1",
+            "description": "This is a valid task description that is definitely "
+            "longer than one hundred characters to satisfy the prd validator rule.",
+            "acceptance_criteria": [
+                "Must update tests/test_module.py",
+                "Should also update src/core.py",
+            ],
+            "owner": "ralph",
+            "depends_on": [],
+        }
+        all_task_ids = {"T1"}
+
+        validator.validate(task, all_task_ids)


### PR DESCRIPTION
## [M3-02] prd_validator

**Epic:** M3
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement PrdValidator: shared validation layer used by both PrdGenerator (M3-03) and PlanChecker. Enforces 4 rules: description >= 100 chars; at least one AC references a file path (contains '.py', 'tests/', or a filename pattern); no credential strings in ralph-owned task descriptions (regex: password|secret|token|api.?key, case-insensitive); all depends_on IDs exist in the tasks list. Raises PlanInvalidError with field name and reason on any failure. See DESIGN.md: PrdValidator.

### Acceptance Criteria
['PrdValidator class with validate(task: dict, all_task_ids: set[str]) -> None method', 'Rule 1: raises PlanInvalidError if task description is shorter than 100 characters', "Rule 2: raises PlanInvalidError if no acceptance criterion contains a file path pattern (r'[\\w/]+\\.py|tests/')", "Rule 3: raises PlanInvalidError if description matches r'(?i)(password|secret|api.?key|token)' for ralph-owned tasks", 'Rule 4: raises PlanInvalidError if any depends_on ID is not in all_task_ids', 'PlanChecker.check_structural() calls PrdValidator.validate() for each incomplete task instead of duplicating the logic', "Tests: each rule has a dedicated test — short description fails R1, description without file ref fails R2, description with 'secret' fails R3, unknown depends_on ID fails R4, valid task passes all rules"]

---
*Ralph Loop — multi-agent AI pair programming*