### PR TITLE
[M2-01] unit_tests_task_tracker_plan_checker

### DIFF
--- a/tests/test_plan_checker.py
+++ b/tests/test_plan_checker.py
@@ -5,6 +5,132 @@ import pytest
 from ralph import PlanChecker, PlanInvalidError
 
 
+class TestPlanCheckerStructuralValidation:
+    def test_structural_validation_fails_missing_required_field(self, tmp_path):
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                }
+            ]
+        }
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        task_tracker.load.return_value = prd
+
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+        errors = checker.check_structural(prd)
+
+        missing_title = any("missing fields" in e and "title" in e for e in errors)
+        assert missing_title
+
+    def test_empty_acceptance_criteria_caught(self, tmp_path):
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Test Task",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": [],
+                    "owner": "ralph",
+                    "completed": False,
+                }
+            ]
+        }
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        task_tracker.load.return_value = prd
+
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+        errors = checker.check_structural(prd)
+
+        assert any("acceptance_criteria is empty" in e for e in errors)
+
+    def test_unresolved_depends_on_raises_error(self, tmp_path):
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Test Task",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                    "depends_on": ["NONEXISTENT"],
+                }
+            ]
+        }
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        task_tracker.load.return_value = prd
+
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+        errors = checker.check_structural(prd)
+
+        assert any("depends_on unknown task 'NONEXISTENT'" in e for e in errors)
+
+
+class TestPlanCheckerComplexityInference:
+    def test_complexity_inference_scores_1_for_simple_tasks(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+
+        simple_task = {
+            "description": "Simple task",
+            "acceptance_criteria": ["AC1"],
+            "files": [],
+        }
+        score = checker._infer_complexity(simple_task)
+        assert score == 1
+
+    def test_complexity_inference_scores_2_for_moderate_tasks(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+
+        moderate_task = {
+            "description": "Medium task description with more words",
+            "acceptance_criteria": ["AC1", "AC2", "AC3", "AC4", "AC5"],
+            "files": ["file1.py"],
+        }
+        score = checker._infer_complexity(moderate_task)
+        assert score == 2
+
+    def test_complexity_inference_scores_3_for_complex_tasks(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text('{"tasks": []}')
+
+        task_tracker = MagicMock()
+        checker = PlanChecker(task_tracker, MagicMock(), MagicMock())
+
+        complex_task = {
+            "description": "This is a refactor task that requires redesign and migration "
+            "of existing code to a new architecture with many components",
+            "acceptance_criteria": ["AC1", "AC2", "AC3", "AC4", "AC5", "AC6"],
+            "files": ["file1.py", "file2.py", "file3.py", "file4.py"],
+        }
+        score = checker._infer_complexity(complex_task)
+        assert score == 3
+
+
 def test_check_structural_valid():
     prd = {
         "tasks": [
@@ -30,7 +156,6 @@ def test_check_structural_missing_field():
             {
                 "id": "T1",
                 "title": "T1",
-                # missing description
                 "acceptance_criteria": ["AC1"],
                 "owner": "ralph",
                 "completed": False,
@@ -84,21 +209,18 @@ def test_check_structural_unresolved_dep():
 def test_infer_complexity():
     checker = PlanChecker(MagicMock(), MagicMock(), MagicMock())
 
-    # Complexity 1
     t1 = {
         "description": "Small task",
         "acceptance_criteria": ["AC1"],
     }
     assert checker._infer_complexity(t1) == 1
 
-    # Complexity 2 (AC count > 4)
     t2 = {
         "description": "Medium task",
         "acceptance_criteria": ["AC1", "AC2", "AC3", "AC4", "AC5"],
     }
     assert checker._infer_complexity(t2) == 2
 
-    # Complexity 3 (Many reasons)
     t3 = {
         "description": "Large refactor task " + "word " * 100,
         "acceptance_criteria": ["AC1", "AC2", "AC3", "AC4", "AC5"],
@@ -148,7 +270,7 @@ def test_auto_decompose():
 
 
 def test_run_raises_invalid_plan():
-    prd = {"tasks": [{"id": "T1", "completed": False}]}  # missing fields
+    prd = {"tasks": [{"id": "T1", "completed": False}]}
     checker = PlanChecker(MagicMock(), MagicMock(), MagicMock())
 
     with pytest.raises(PlanInvalidError):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -1,7 +1,123 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from ralph import PRDGuardViolation, TaskTracker
+
+
+class TestTaskTrackerFreshLoad:
+    def test_fresh_load_reads_disk_each_call(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_data = {"tasks": [{"id": "T1", "completed": False}]}
+        prd_file.write_text(json.dumps(prd_data))
+
+        tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
+
+        result1 = tracker.load()
+        result1["tasks"][0]["completed"] = True
+
+        result2 = tracker.load()
+        assert result2["tasks"][0]["completed"] is False
+
+
+class TestTaskTrackerGetNextTask:
+    def test_get_next_task_returns_incomplete_ralph_owned_task(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_data = {
+            "tasks": [
+                {"id": "T1", "owner": "ralph", "completed": False},
+                {"id": "T2", "owner": "ralph", "completed": False},
+            ]
+        }
+        prd_file.write_text(json.dumps(prd_data))
+        tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
+
+        task = tracker.get_next_task()
+        assert task is not None
+        assert task["owner"] == "ralph"
+        assert task["completed"] is False
+        assert task["id"] == "T1"
+
+    def test_get_next_task_skips_human_owned_tasks(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_data = {
+            "tasks": [
+                {"id": "T1", "owner": "human", "completed": False},
+                {"id": "T2", "owner": "ralph", "completed": False},
+            ]
+        }
+        prd_file.write_text(json.dumps(prd_data))
+        tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
+
+        task = tracker.get_next_task()
+        assert task is not None
+        assert task["id"] == "T2"
+        assert task["owner"] == "ralph"
+
+    def test_get_next_task_respects_depends_on_completion(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_data = {
+            "tasks": [
+                {"id": "T1", "owner": "ralph", "completed": False},
+                {"id": "T2", "owner": "ralph", "completed": False, "depends_on": ["T1"]},
+                {"id": "T3", "owner": "ralph", "completed": False, "depends_on": ["T1", "T2"]},
+            ]
+        }
+        prd_file.write_text(json.dumps(prd_data))
+        tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
+
+        task1 = tracker.get_next_task()
+        assert task1["id"] == "T1"
+
+        tracker.mark_complete("T1")
+
+        task2 = tracker.get_next_task()
+        assert task2["id"] == "T2"
+
+        tracker.mark_complete("T2")
+
+        task3 = tracker.get_next_task()
+        assert task3["id"] == "T3"
+
+
+class TestTaskTrackerMarkComplete:
+    def test_mark_complete_writes_back_to_disk(self, tmp_path):
+        prd_file = tmp_path / "prd.json"
+        prd_data = {"tasks": [{"id": "T1", "completed": False, "owner": "ralph"}]}
+        prd_file.write_text(json.dumps(prd_data))
+        tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
+
+        tracker.mark_complete("T1")
+
+        loaded = tracker.load()
+        assert loaded["tasks"][0]["completed"] is True
+
+
+class TestTaskTrackerCommitTracking:
+    def test_commit_tracking_issues_correct_git_commands(self, tmp_path):
+        runner = MagicMock()
+        prd_file = tmp_path / "prd.json"
+        progress_file = tmp_path / "progress.txt"
+        prd_file.write_text("{}")
+        progress_file.write_text("")
+
+        tracker = TaskTracker(prd_file, progress_file, runner, MagicMock())
+
+        tracker.commit_tracking("T1", "Test Task")
+
+        assert runner.run.call_count == 3
+
+        calls = runner.run.call_args_list
+
+        assert calls[0][0][0] == ["git", "add", str(prd_file), str(progress_file)]
+        assert calls[0][1]["check"] is True
+
+        assert calls[1][0][0] == ["git", "commit", "-m", "[T1] Test Task: mark complete"]
+        assert calls[1][1]["check"] is True
+
+        assert calls[2][0][0] == ["git", "push", "origin", "main"]
+        assert calls[2][1]["check"] is True
 
 
 def test_task_tracker_load(tmp_path):
@@ -27,12 +143,6 @@ def test_get_next_task(tmp_path):
     prd_file.write_text(json.dumps(prd_data))
     tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
 
-    # T1 is completed.
-    # T2 is human.
-    # T3 depends on T4 (incomplete).
-    # T4 is next available ralph task.
-    # T5 depends on T1 (completed), so it would be next after T4.
-
     task = tracker.get_next_task()
     assert task["id"] == "T4"
 
@@ -53,8 +163,6 @@ def test_mark_complete_already_done(tmp_path):
     prd_file.write_text(json.dumps(prd_data))
     tracker = TaskTracker(prd_file, tmp_path / "progress.txt", MagicMock(), MagicMock())
 
-    import pytest
-
     with pytest.raises(PRDGuardViolation):
         tracker.mark_complete("T1")
 
@@ -65,19 +173,6 @@ def test_append_progress(tmp_path):
 
     tracker.append_progress("T1", "Title", 123, "2026-04-20")
     assert progress_file.read_text() == "2026-04-20 | T1 | Title | PR #123\n"
-
-
-def test_commit_tracking(tmp_path):
-    runner = MagicMock()
-    prd_file = tmp_path / "prd.json"
-    progress_file = tmp_path / "progress.txt"
-    tracker = TaskTracker(prd_file, progress_file, runner, MagicMock())
-
-    tracker.commit_tracking("T1", "Title")
-
-    assert runner.run.call_count == 3
-    # Check git add
-    runner.run.assert_any_call(["git", "add", str(prd_file), str(progress_file)], check=True)
 
 
 def test_add_task(tmp_path):


### PR DESCRIPTION
## [M2-01] unit_tests_task_tracker_plan_checker

**Epic:** M2
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Write comprehensive unit tests for TaskTracker and PlanChecker classes in ralph.py. TaskTracker tests must verify: fresh load behavior (never cached state), get_next_task() filtering by completed=false, owner filtering excluding human tasks, depends_on validation ensuring only completed dependencies are eligible, mark_complete atomicity, and commit_tracking git command sequence. PlanChecker tests must verify: structural validation catching missing fields (title, description, acceptance_criteria), empty AC list detection, unresolved depends_on catching non-existent task IDs, complexity inference scoring based on AC count, word count, file count, and keyword matching. All tests must use tmp_path for filesystem isolation and mock SubprocessRunner to avoid actual git calls.

### Acceptance Criteria
['tests/test_task_tracker.py: test_fresh_load_reads_disk_each_call, test_get_next_task_returns_incomplete_ralph_owned_task, test_get_next_task_skips_human_owned_tasks, test_get_next_task_respects_depends_on_completion, test_mark_complete_writes_back_to_disk, test_commit_tracking_issues_correct_git_commands', 'tests/test_plan_checker.py: test_structural_validation_fails_missing_required_field, test_empty_acceptance_criteria_caught, test_unresolved_depends_on_raises_error, test_complexity_inference_scores_1_for_simple_tasks, test_complexity_inference_scores_2_for_moderate_tasks, test_complexity_inference_scores_3_for_complex_tasks', 'All tests pass with uv run pytest tests/ -v']

---
*Ralph Loop — multi-agent AI pair programming*