### PR TITLE
[M2-02] unit_tests_branch_manager_prd_guard

### DIFF
--- a/tests/test_branch_manager.py
+++ b/tests/test_branch_manager.py
@@ -6,79 +6,161 @@ import pytest
 from ralph import BranchExistsError, BranchManager, RemoteNotSSHError
 
 
+def test_verify_ssh_remote_raises_on_https_url():
+    runner = MagicMock()
+    runner.run.return_value.stdout = "https://github.com/org/repo.git\n"
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
+
+    with pytest.raises(RemoteNotSSHError) as excinfo:
+        manager.verify_ssh_remote()
+
+    assert "HTTPS remote detected" in str(excinfo.value)
+    runner.run.assert_called_once_with(["git", "remote", "get-url", "origin"], cwd=Path("."))
+
+
 def test_verify_ssh_remote_success():
     runner = MagicMock()
     runner.run.return_value.stdout = "git@github.com:org/repo.git\n"
-    manager = BranchManager(Path("."), runner, MagicMock())
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
 
     manager.verify_ssh_remote()
-    runner.run.assert_called_with(["git", "remote", "get-url", "origin"], cwd=Path("."))
+    runner.run.assert_called_once_with(["git", "remote", "get-url", "origin"], cwd=Path("."))
 
 
-def test_verify_ssh_remote_failure():
+def test_ensure_main_up_to_date_uses_reset_not_pull():
     runner = MagicMock()
-    runner.run.return_value.stdout = "https://github.com/org/repo.git\n"
-    manager = BranchManager(Path("."), runner, MagicMock())
-
-    with pytest.raises(RemoteNotSSHError):
-        manager.verify_ssh_remote()
-
-
-def test_ensure_main_up_to_date():
-    runner = MagicMock()
-    manager = BranchManager(Path("."), runner, MagicMock())
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
 
     manager.ensure_main_up_to_date()
 
-    assert runner.run.call_count == 3
-    runner.run.assert_any_call(["git", "checkout", "main"], cwd=Path("."), check=True)
-    runner.run.assert_any_call(["git", "fetch", "origin", "main"], cwd=Path("."), check=True)
-    runner.run.assert_any_call(["git", "reset", "--hard", "origin/main"], cwd=Path("."), check=True)
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+
+    assert ["git", "checkout", "main"] in cmd_lists
+    assert ["git", "fetch", "origin", "main"] in cmd_lists
+    assert ["git", "reset", "--hard", "origin/main"] in cmd_lists
+
+    for cmd in cmd_lists:
+        assert "pull" not in cmd, "ensure_main_up_to_date must use reset --hard, not pull"
+        assert "--ff-only" not in cmd, (
+            "ensure_main_up_to_date must use reset --hard, not pull --ff-only"
+        )
 
 
-def test_checkout_or_create_new():
+def test_checkout_or_create_raises_on_existing_branch_no_resume():
     runner = MagicMock()
-    # Mock branch list empty
+    runner.run.return_value.stdout = "  existing-branch\n"
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
+
+    with pytest.raises(BranchExistsError) as excinfo:
+        manager.checkout_or_create("existing-branch", resume=False)
+
+    assert "existing-branch" in str(excinfo.value)
+    assert "resume=False" in str(excinfo.value)
+
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+    assert ["git", "branch", "--list", "existing-branch"] in cmd_lists
+
+
+def test_checkout_or_create_creates_new_branch_when_not_exists():
+    runner = MagicMock()
     runner.run.side_effect = [
-        MagicMock(stdout=""),  # git branch --list
+        MagicMock(stdout=""),  # git branch --list (empty - branch doesn't exist)
         MagicMock(returncode=0),  # git checkout -b
-        MagicMock(stdout="0\n"),  # git rev-list
+        MagicMock(stdout="0\n"),  # git rev-list (no commits)
     ]
-    manager = BranchManager(Path("."), runner, MagicMock())
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
 
     status = manager.checkout_or_create("new-branch", resume=False)
 
     assert status.existed is False
     assert status.had_commits is False
-    runner.run.assert_any_call(["git", "checkout", "-b", "new-branch"], cwd=Path("."), check=True)
+
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+    assert ["git", "checkout", "-b", "new-branch"] in cmd_lists
 
 
-def test_checkout_or_create_exists_no_resume():
-    runner = MagicMock()
-    runner.run.return_value.stdout = "  existing-branch\n"
-    manager = BranchManager(Path("."), runner, MagicMock())
-
-    with pytest.raises(BranchExistsError):
-        manager.checkout_or_create("existing-branch", resume=False)
-
-
-def test_checkout_or_create_exists_resume():
+def test_checkout_or_create_resumes_existing_branch():
     runner = MagicMock()
     runner.run.side_effect = [
         MagicMock(stdout="  existing-branch\n"),  # git branch --list
         MagicMock(returncode=0),  # git checkout
-        MagicMock(stdout="5\n"),  # git rev-list
+        MagicMock(stdout="5\n"),  # git rev-list (has commits)
     ]
-    manager = BranchManager(Path("."), runner, MagicMock())
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
 
     status = manager.checkout_or_create("existing-branch", resume=True)
 
     assert status.existed is True
     assert status.had_commits is True
-    runner.run.assert_any_call(["git", "checkout", "existing-branch"], cwd=Path("."), check=True)
+
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+    assert ["git", "checkout", "existing-branch"] in cmd_lists
 
 
-def test_sanitise_branch_name():
-    manager = BranchManager(Path("."), MagicMock(), MagicMock())
-    assert manager.sanitise_branch_name("Feature: Add New UI!") == "feature--add-new-ui"
-    assert len(manager.sanitise_branch_name("A" * 100)) == 40
+def test_sanitise_branch_name_truncates_to_40_chars():
+    logger = MagicMock()
+    manager = BranchManager(Path("."), MagicMock(), logger)
+
+    result = manager.sanitise_branch_name("A" * 100)
+    assert len(result) == 40
+
+
+def test_sanitise_branch_name_transforms_title():
+    logger = MagicMock()
+    manager = BranchManager(Path("."), MagicMock(), logger)
+
+    result = manager.sanitise_branch_name("Feature: Add New UI!")
+    assert result == "feature--add-new-ui"
+    assert len(result) <= 40
+
+
+def test_push_verifies_ssh_before_executing():
+    runner = MagicMock()
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
+
+    runner.run.return_value.stdout = "git@github.com:org/repo.git\n"
+
+    manager.push_branch("test-branch")
+
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+
+    verify_ssh_call = [c for c in cmd_lists if "remote" in c and "get-url" in c]
+    push_call = [c for c in cmd_lists if c[0] == "git" and c[1] == "push"]
+
+    assert len(verify_ssh_call) == 1, "verify_ssh_remote must be called before push"
+    assert len(push_call) == 1, "push command must be executed"
+
+    verify_ssh_index = cmd_lists.index(verify_ssh_call[0])
+    push_index = cmd_lists.index(push_call[0])
+
+    assert verify_ssh_index < push_index, "verify_ssh_remote must be called before push"
+
+
+def test_delete_remote_verifies_ssh():
+    runner = MagicMock()
+    logger = MagicMock()
+    manager = BranchManager(Path("."), runner, logger)
+
+    runner.run.return_value.stdout = "git@github.com:org/repo.git\n"
+
+    manager.delete_remote("test-branch")
+
+    calls = runner.run.call_args_list
+    cmd_lists = [c[0][0] for c in calls]
+
+    verify_ssh_call = [c for c in cmd_lists if "remote" in c and "get-url" in c]
+
+    assert len(verify_ssh_call) == 1, "verify_ssh_remote must be called before delete"
+    assert verify_ssh_call[0] == ["git", "remote", "get-url", "origin"]

--- a/tests/test_prd_guard.py
+++ b/tests/test_prd_guard.py
@@ -5,16 +5,34 @@ import pytest
 from ralph import PRDGuard, PRDGuardViolation
 
 
-def test_prd_guard_clean():
+def test_empty_prd_diff_passes():
     pr_manager = MagicMock()
     pr_manager.get_diff_for_file.return_value = ""
     guard = PRDGuard(pr_manager, MagicMock())
 
-    # Should not raise
     guard.check(42)
 
+    pr_manager.get_diff_for_file.assert_called_once_with(42, "prd.json")
 
-def test_prd_guard_violation():
+
+def test_any_prd_modification_raises_violation():
+    pr_manager = MagicMock()
+    pr_manager.get_diff_for_file.return_value = """--- a/prd.json
++++ b/prd.json
+@@ -10,1 +10,2 @@
++    "added_field": "value",
+"""
+    guard = PRDGuard(pr_manager, MagicMock())
+
+    with pytest.raises(PRDGuardViolation) as excinfo:
+        guard.check(42)
+
+    assert "PR #42" in str(excinfo.value)
+    assert "prd.json must not be modified" in str(excinfo.value)
+    assert '"added_field"' in str(excinfo.value)
+
+
+def test_completed_true_change_raises_violation():
     pr_manager = MagicMock()
     pr_manager.get_diff_for_file.return_value = """--- a/prd.json
 +++ b/prd.json
@@ -26,18 +44,41 @@ def test_prd_guard_violation():
     with pytest.raises(PRDGuardViolation) as excinfo:
         guard.check(42)
 
-    assert "PR #42 violated PRDGuard" in str(excinfo.value)
-    assert '"completed": true,' in str(excinfo.value)
+    assert "PR #42" in str(excinfo.value)
+    assert '"completed": true' in str(excinfo.value)
 
 
-def test_prd_guard_any_addition_violation():
+def test_violation_includes_pr_number_and_offending_lines():
     pr_manager = MagicMock()
     pr_manager.get_diff_for_file.return_value = """--- a/prd.json
 +++ b/prd.json
-@@ -10,1 +10,2 @@
-+    "some_other_field": "value",
+@@ -5,3 +5,5 @@
+      "tasks": [
+        {
++          "new_task": "added",
+          "id": "M1-01",
+-          "id": "M1-02",
++          "id": "M1-03",
 """
     guard = PRDGuard(pr_manager, MagicMock())
 
-    with pytest.raises(PRDGuardViolation):
-        guard.check(42)
+    with pytest.raises(PRDGuardViolation) as excinfo:
+        guard.check(123)
+
+    error_msg = str(excinfo.value)
+    assert "PR #123" in error_msg
+    assert "new_task" in error_msg or '"new_task"' in error_msg
+
+
+def test_diff_with_only_deletions_passes():
+    pr_manager = MagicMock()
+    pr_manager.get_diff_for_file.return_value = """--- a/prd.json
++++ b/prd.json
+@@ -10,1 +10,0 @@
+-    "removed_field": "value",
+"""
+    guard = PRDGuard(pr_manager, MagicMock())
+
+    guard.check(42)
+
+    pr_manager.get_diff_for_file.assert_called_once_with(42, "prd.json")


### PR DESCRIPTION
## [M2-02] unit_tests_branch_manager_prd_guard

**Epic:** M2
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Write comprehensive unit tests for BranchManager and PRDGuard classes in ralph.py. BranchManager tests must verify: SSH remote enforcement rejecting HTTPS remotes, ensure_main_up_to_date using reset --hard (never pull --ff-only), checkout_or_create raising BranchExistsError when resume=False and branch exists, sanitise_branch_name transforming titles to 40-char hyphenated lowercase, and that verify_ssh_remote() is called before every push operation. PRDGuard tests must verify: detecting any modification to prd.json via diff parsing, catching completed=true changes specifically, and raising PRDGuardViolation with the offending PR number and diff lines. All tests must mock SubprocessRunner and verify exact git command sequences via call inspection.

### Acceptance Criteria
['tests/test_branch_manager.py: test_verify_ssh_remote_raises_on_https_url, test_ensure_main_up_to_date_uses_reset_not_pull, test_checkout_or_create_raises_on_existing_branch_no_resume, test_checkout_or_create_creates_new_branch_when_not_exists, test_sanitise_branch_name_truncates_to_40_chars, test_push_verifies_ssh_before_executing', 'tests/test_prd_guard.py: test_empty_prd_diff_passes, test_any_prd_modification_raises_violation, test_completed_true_change_raises_violation, test_violation_includes_pr_number_and_offending_lines', 'All tests pass with uv run pytest tests/ -v']

---
*Ralph Loop — multi-agent AI pair programming*