### PR TITLE
[M2-05] coverage_threshold_seventy_percent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,15 @@ select = ["E", "F", "I", "N", "W"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"
+
+[tool.coverage.run]
+source = ["ralph"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 70
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]


### PR DESCRIPTION
## [M2-05] coverage_threshold_seventy_percent

**Epic:** M2
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Configure pytest-cov to enforce a minimum 70% line coverage threshold matching GSD's quality bar. This requires updating pyproject.toml to add pytest-cov dependency, configuring coverage to measure ralph.py specifically (excluding tests/ directory), and setting fail_under=70 in the coverage report configuration. Run the full test suite to establish baseline coverage, identify any gaps in existing tests, and add minimal tests to reach the threshold. Document the coverage command in quality_checks. The coverage report must generate both terminal output and HTML reports for debugging. This ensures the codebase maintains testability and prevents regression as new features are added.

### Acceptance Criteria
['pyproject.toml: pytest-cov added to dev dependencies, coverage configuration with fail_under=70, source=ralph.py, omit=tests/*', 'quality_checks in prd.json updated to include uv run pytest tests/ --cov=ralph.py --cov-report=term-missing --cov-fail-under=70 -v', 'Coverage baseline report generated and stored, confirming ≥70% line coverage for ralph.py', 'HTML coverage report generated at htmlcov/index.html for debugging uncovered lines', 'All existing tests pass with new coverage configuration']

---
*Ralph Loop — multi-agent AI pair programming*