### PR TITLE
[M2-06] validate_plan_flag_tier_two_ai

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -179,6 +179,7 @@ class Config:
     claude_only: bool = False
     gemini_only: bool = False
     opencode_only: bool = False
+    validate_plan: bool = False  # Tier 2 AI sanity check on prd.json
 
 
 @dataclass
@@ -1129,11 +1130,14 @@ class PlanChecker:
         if errors:
             raise PlanInvalidError("\n".join(errors))
 
-        # ai_check (M2 feature) produces warnings only
         warnings = []
         if ai_check:
-            # warnings = self.ai_runner.check_ai(prd["tasks"])
-            pass
+            pending_tasks = [t for t in prd.get("tasks", []) if not t.get("completed")]
+            if pending_tasks:
+                prompt = PromptBuilder.plan_check_prompt(pending_tasks)
+                ai_response = self.ai_runner.run_reviewer("gemini", prompt)
+                if ai_response:
+                    warnings = self._parse_warnings(ai_response)
 
         decompositions = self.auto_decompose(prd)
 
@@ -1144,6 +1148,15 @@ class PlanChecker:
             tasks_checked=sum(1 for t in prd.get("tasks", []) if not t.get("completed")),
             decompositions=decompositions,
         )
+
+    def _parse_warnings(self, ai_response: str) -> list[str]:
+        """Parse [WARN] task_id: reason lines from AI response."""
+        warnings = []
+        for line in ai_response.splitlines():
+            match = re.match(r"\[WARN\]\s+(\S+):\s+(.+)", line)
+            if match:
+                warnings.append(f"{match.group(1)}: {match.group(2)}")
+        return warnings
 
 
 class BranchManager:
@@ -2379,7 +2392,9 @@ class Orchestrator:
             )
 
         try:
-            self.plan_checker.run(prd)
+            check_result = self.plan_checker.run(prd, ai_check=self.config.validate_plan)
+            for warning in check_result.warnings:
+                self.logger.warn(f"[AI Plan Check] {warning}")
         except PlanInvalidError as e:
             raise PreflightError(f"Plan validation failed: {e}") from e
 
@@ -2792,6 +2807,7 @@ def run(
         claude_only=claude_only,
         gemini_only=gemini_only,
         opencode_only=opencode_only,
+        validate_plan=validate_plan,
     )
 
     logger = RalphLogger(log_file)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -147,7 +147,7 @@ class TestPreflight:
             or MagicMock(returncode=0)
         )
         orch.plan_checker = MagicMock(spec=PlanChecker)
-        orch.plan_checker.run = lambda prd: call_order.append(("plan_check_run",))
+        orch.plan_checker.run = lambda prd, ai_check=False: call_order.append(("plan_check_run",))
 
         try:
             orch._preflight({})

--- a/tests/test_validate_plan.py
+++ b/tests/test_validate_plan.py
@@ -1,0 +1,210 @@
+from unittest.mock import MagicMock
+
+from ralph import Config, PlanChecker
+
+
+class TestValidatePlanFlag:
+    """Tests for the --validate-plan CLI flag and PlanChecker AI validation."""
+
+    def test_flag_triggers_ai_validation(self):
+        """When ai_check=True, PlanChecker.run() should call AIRunner."""
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        ai_runner.run_reviewer.return_value = "No issues found."
+
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Test Task",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                }
+            ]
+        }
+
+        checker = PlanChecker(task_tracker, ai_runner, logger)
+        result = checker.run(prd, ai_check=True)
+
+        ai_runner.run_reviewer.assert_called_once()
+        assert result.tasks_checked == 1
+
+    def test_warn_format_parsed_correctly(self):
+        """PlanChecker should parse [WARN] task_id: reason format correctly."""
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        ai_runner.run_reviewer.return_value = """
+Some introductory text.
+[WARN] T1: acceptance criteria is too vague - "it works correctly" is not measurable
+[WARN] T2: task has multiple distinct deliverables - should be split
+More context here.
+"""
+
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Task 1",
+                    "description": "Task 1 description with enough characters "
+                    "to meet the minimum length requirement for valid tasks in ralph.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                },
+                {
+                    "id": "T2",
+                    "title": "Task 2",
+                    "description": "Task 2 description with enough characters "
+                    "to meet the minimum length requirement for valid tasks in ralph.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                },
+            ]
+        }
+
+        checker = PlanChecker(task_tracker, ai_runner, logger)
+        result = checker.run(prd, ai_check=True)
+
+        assert len(result.warnings) == 2
+        assert "T1: acceptance criteria is too vague" in result.warnings[0]
+        assert "T2: task has multiple distinct deliverables" in result.warnings[1]
+
+    def test_warnings_logged_but_do_not_block(self):
+        """Warnings should not raise PlanInvalidError or block execution."""
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        ai_runner.run_reviewer.return_value = "[WARN] T1: vague acceptance criteria"
+
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Test Task",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                }
+            ]
+        }
+
+        checker = PlanChecker(task_tracker, ai_runner, logger)
+        result = checker.run(prd, ai_check=True)
+
+        assert result.valid is True
+        assert len(result.warnings) == 1
+        assert "T1" in result.warnings[0]
+        assert "vague acceptance criteria" in result.warnings[0]
+
+    def test_no_ai_call_when_flag_false(self):
+        """When ai_check=False, AIRunner should NOT be called."""
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        prd = {
+            "tasks": [
+                {
+                    "id": "T1",
+                    "title": "Test Task",
+                    "description": "This is a valid task description that is definitely longer "
+                    "than one hundred characters to satisfy the prd validator rule.",
+                    "acceptance_criteria": ["Must update tests/test_module.py"],
+                    "owner": "ralph",
+                    "completed": False,
+                }
+            ]
+        }
+
+        checker = PlanChecker(task_tracker, ai_runner, logger)
+        result = checker.run(prd, ai_check=False)
+
+        ai_runner.run_reviewer.assert_not_called()
+        assert result.valid is True
+        assert result.warnings == []
+
+
+class TestConfigValidatePlan:
+    """Tests for Config.validate_plan field."""
+
+    def test_validate_plan_default_false(self):
+        """validate_plan should default to False."""
+        config = Config(
+            max_iterations=1,
+            skip_review=False,
+            tdd_mode=False,
+            model_mode="random",
+            opencode_model="opencode/kimi-k2.5",
+            resume=False,
+            repo_dir=MagicMock(),
+            log_file=MagicMock(),
+            max_precommit_rounds=2,
+            max_review_rounds=2,
+            max_ci_fix_rounds=2,
+            max_test_fix_rounds=2,
+            max_test_write_rounds=2,
+            force_task_id=None,
+        )
+        assert config.validate_plan is False
+
+    def test_validate_plan_can_be_set_true(self):
+        """validate_plan can be explicitly set to True."""
+        config = Config(
+            max_iterations=1,
+            skip_review=False,
+            tdd_mode=False,
+            model_mode="random",
+            opencode_model="opencode/kimi-k2.5",
+            resume=False,
+            repo_dir=MagicMock(),
+            log_file=MagicMock(),
+            max_precommit_rounds=2,
+            max_review_rounds=2,
+            max_ci_fix_rounds=2,
+            max_test_fix_rounds=2,
+            max_test_write_rounds=2,
+            force_task_id=None,
+            validate_plan=True,
+        )
+        assert config.validate_plan is True
+
+
+class TestPlanCheckResultWarnings:
+    """Tests for PlanCheckResult warnings field."""
+
+    def test_plan_check_result_has_warnings_field(self):
+        """PlanCheckResult should have warnings field."""
+        from ralph import PlanCheckResult
+
+        result = PlanCheckResult(
+            valid=True,
+            errors=[],
+            warnings=["T1: vague AC"],
+            tasks_checked=1,
+            decompositions=0,
+        )
+        assert result.warnings == ["T1: vague AC"]
+
+    def test_plan_check_result_warnings_default_empty(self):
+        """warnings should default to empty list."""
+        from ralph import PlanCheckResult
+
+        result = PlanCheckResult(
+            valid=True,
+            errors=[],
+            warnings=[],
+            tasks_checked=1,
+            decompositions=0,
+        )
+        assert result.warnings == []


### PR DESCRIPTION
## [M2-06] validate_plan_flag_tier_two_ai

**Epic:** M2
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement the --validate-plan CLI flag that triggers PlanChecker Tier 2 AI sanity check using AIRunner. When --validate-plan is passed, the orchestrator must run an enhanced validation before starting the sprint. The AI validator receives all pending tasks via PromptBuilder.plan_check_prompt() and analyzes them for untestable acceptance criteria (vague language like 'works correctly' without measurable outcomes), non-atomic tasks (ACs that imply multiple distinct implementations), and unresolved contradictions between dependent tasks. Warnings are logged but do not block execution. The AI response is parsed for [WARN] task_id: reason lines. This catches planning errors early before ralph invests compute in implementation.

### Acceptance Criteria
['ralph.py: --validate-plan flag added to CLI, mapped to Config.validate_plan: bool field', 'PlanChecker.run() accepts ai_check: bool parameter, when True calls AIRunner with plan_check_prompt', 'PromptBuilder.plan_check_prompt(tasks: list[dict]) -> str: instructs AI to flag untestable ACs, non-atomic tasks, contradictions using [WARN] task_id: reason format', 'Orchestrator._preflight() calls PlanChecker with ai_check=config.validate_plan when flag is set', 'Warnings are logged at WARN level but do not raise PlanInvalidError or block execution', 'tests/test_validate_plan.py: test_flag_triggers_ai_validation, test_warn_format_parsed_correctly, test_warnings_logged_but_do_not_block, test_no_ai_call_when_flag_false']

---
*Ralph Loop — multi-agent AI pair programming*