### PR TITLE
[M4-03] unblockstrategy_per_blocker_recovery

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -1801,10 +1801,249 @@ class PRDGuard:
 
 
 @dataclass
+class UnblockResult:
+    success: bool
+    actions_log: list[str]
+    escalated: bool = False
+    replacement_task_id: str | None = None
+    skip_to_next: bool = False
+    alternative_model: str | None = None
+
+
+@dataclass
 class BlockerResult:
     kind: BlockerKind
     task_id: str | None
     context: str
+
+
+class UnblockStrategy:
+    """
+    Provides specific recovery tactics for each BlockerKind variant.
+
+    For MERGE_CONFLICT: abort merge, reset branch, and re-apply changes.
+    For CI_FATAL: create FIX ticket with failure context and skip to next task.
+    For PRD_GUARD_VIOLATION: rollback PR, mark task for human review, create replacement task.
+    For REVIEWER_UNAVAILABLE: switch to alternative reviewer model or enable skip-review mode.
+
+    Each strategy logs actions taken and returns success/failure status for escalation.
+    """
+
+    def __init__(
+        self,
+        branch_manager: BranchManager,
+        pr_manager: PRManager,
+        task_tracker: TaskTracker,
+        ai_runner: "AIRunner",
+        logger: RalphLogger,
+    ):
+        self.branch_manager = branch_manager
+        self.pr_manager = pr_manager
+        self.task_tracker = task_tracker
+        self.ai_runner = ai_runner
+        self.logger = logger
+
+    def execute(
+        self,
+        blocker: BlockerResult,
+        task: dict,
+        prd: dict,
+    ) -> UnblockResult:
+        """Execute the appropriate unblocking strategy based on blocker kind."""
+        if blocker.kind == BlockerKind.MERGE_CONFLICT:
+            return self._handle_merge_conflict(blocker, task)
+        elif blocker.kind == BlockerKind.CI_FATAL:
+            return self._handle_ci_fatal(blocker, task)
+        elif blocker.kind == BlockerKind.PRD_GUARD_VIOLATION:
+            return self._handle_prd_guard_violation(blocker, task, prd)
+        elif blocker.kind == BlockerKind.REVIEWER_UNAVAILABLE:
+            return self._handle_reviewer_unavailable(blocker, task)
+        else:
+            return UnblockResult(
+                success=False,
+                actions_log=[f"Unknown blocker kind: {blocker.kind}"],
+                escalated=True,
+            )
+
+    def _handle_merge_conflict(
+        self,
+        blocker: BlockerResult,
+        task: dict,
+    ) -> UnblockResult:
+        """Abort merge, reset branch, and re-apply changes."""
+        actions: list[str] = []
+        task_id = task.get("id", "unknown")
+
+        actions.append(f"Detected merge conflict for task {task_id}")
+        actions.append(f"Context: {blocker.context[:100]}")
+
+        branch = f"ralph/{task_id}-{self.branch_manager.sanitise_branch_name(task['title'])}"
+
+        try:
+            actions.append(f"Resetting branch {branch} to main")
+            self.branch_manager.runner.run(
+                ["git", "checkout", branch],
+                cwd=self.branch_manager.repo_dir,
+                check=True,
+            )
+            self.branch_manager.runner.run(
+                ["git", "reset", "--hard", f"origin/{MAIN_BRANCH}"],
+                cwd=self.branch_manager.repo_dir,
+                check=True,
+            )
+            actions.append("Branch reset to origin/main")
+
+            actions.append("Re-applying changes via AI coder...")
+            self._reapply_changes(task)
+
+            actions.append("Merge conflict recovery completed successfully")
+            return UnblockResult(
+                success=True,
+                actions_log=actions,
+            )
+        except Exception as e:
+            actions.append(f"Merge conflict recovery failed: {e}")
+            return UnblockResult(
+                success=False,
+                actions_log=actions,
+                escalated=True,
+            )
+
+    def _reapply_changes(self, task: dict) -> None:
+        """Re-invoke the coder to re-apply changes."""
+        prompt = PromptBuilder.coder_prompt(task, "opencode", {}, resume=True)
+        self.ai_runner.run_coder("opencode", prompt, self.branch_manager.repo_dir)
+
+    def _handle_ci_fatal(
+        self,
+        blocker: BlockerResult,
+        task: dict,
+    ) -> UnblockResult:
+        """Create FIX ticket with failure context and skip to next task."""
+        actions: list[str] = []
+        task_id = task.get("id", "unknown")
+
+        actions.append(f"Detected CI fatal for task {task_id}")
+        actions.append(f"Failure context: {blocker.context[:100]}")
+
+        try:
+            ticket_title = f"FIX: {task.get('title', 'Untitled')} - CI failure"
+            ticket_body = (
+                f"CI failure in task {task_id}\n\n"
+                f"Failure context:\n{blocker.context}\n\n"
+                f"Task description: {task.get('description', '')}\n\n"
+                f"Acceptance criteria:\n"
+                + "\n".join(f"- {ac}" for ac in task.get("acceptance_criteria", []))
+            )
+            result = self.branch_manager.runner.run(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--title",
+                    ticket_title,
+                    "--body",
+                    ticket_body,
+                ],
+                check=True,
+            )
+            actions.append(f"Created FIX ticket: {result.stdout.strip()[:100]}")
+            actions.append("Skipping to next task")
+            return UnblockResult(
+                success=True,
+                actions_log=actions,
+                skip_to_next=True,
+            )
+        except Exception as e:
+            actions.append(f"Failed to create FIX ticket: {e}")
+            return UnblockResult(
+                success=False,
+                actions_log=actions,
+                skip_to_next=True,
+                escalated=True,
+            )
+
+    def _handle_prd_guard_violation(
+        self,
+        blocker: BlockerResult,
+        task: dict,
+        prd: dict,
+    ) -> UnblockResult:
+        """Rollback PR, mark task for human review, create replacement task."""
+        actions: list[str] = []
+        task_id = task.get("id", "unknown")
+
+        actions.append(f"Detected PRD guard violation for task {task_id}")
+        actions.append(f"Violation: {blocker.context[:100]}")
+
+        pr_number = task.get("pr_number")
+        if pr_number:
+            try:
+                actions.append(f"Closing PR #{pr_number}")
+                self.pr_manager.close(
+                    pr_number,
+                    "PRD violation: prd.json was modified. Closing for human review.",
+                )
+                actions.append("PR closed and rolled back")
+            except Exception as e:
+                actions.append(f"Failed to close PR: {e}")
+
+        tasks = prd.get("tasks", [])
+        max_epic = 0
+        for t in tasks:
+            tid = t.get("id", "")
+            match = re.match(r"^M(\d+)", tid)
+            if match:
+                max_epic = max(max_epic, int(match.group(1)))
+
+        replacement_task = {
+            "id": f"M{max_epic + 1}-FIX",
+            "title": f"REVIEW: {task.get('title', 'Untitled')}",
+            "description": (
+                f"Human review required for task {task_id}. "
+                f"Original task violated PRD guard (coder modified prd.json). "
+                f"Original description: {task.get('description', '')}"
+            ),
+            "acceptance_criteria": task.get("acceptance_criteria", []),
+            "owner": "human",
+            "completed": False,
+            "depends_on": task.get("depends_on", []),
+            "epic": task.get("epic", f"M{max_epic}"),
+        }
+
+        self.task_tracker.add_task(replacement_task)
+        actions.append(f"Created replacement task: {replacement_task['id']}")
+        actions.append("Marked original task for human review")
+
+        return UnblockResult(
+            success=True,
+            actions_log=actions,
+            replacement_task_id=replacement_task["id"],
+            escalated=True,
+        )
+
+    def _handle_reviewer_unavailable(
+        self,
+        blocker: BlockerResult,
+        task: dict,
+    ) -> UnblockResult:
+        """Switch to alternative reviewer model or enable skip-review mode."""
+        actions: list[str] = []
+        task_id = task.get("id", "unknown")
+
+        actions.append(f"Detected reviewer unavailable for task {task_id}")
+        actions.append(f"Context: {blocker.context[:100]}")
+
+        alternative = "gemini"
+
+        actions.append(f"Switching to alternative reviewer: {alternative}")
+        actions.append("Reviewer unavailable recovery completed successfully")
+
+        return UnblockResult(
+            success=True,
+            actions_log=actions,
+            alternative_model=alternative,
+        )
 
 
 class BlockerAnalyser:

--- a/tests/test_unblock_strategy.py
+++ b/tests/test_unblock_strategy.py
@@ -1,0 +1,371 @@
+from unittest.mock import MagicMock
+
+from ralph import (
+    BlockerKind,
+    BlockerResult,
+    UnblockResult,
+    UnblockStrategy,
+)
+
+
+def test_unblock_result_dataclass():
+    result = UnblockResult(
+        success=True,
+        actions_log=["action 1", "action 2"],
+    )
+
+    assert result.success is True
+    assert len(result.actions_log) == 2
+    assert result.actions_log[0] == "action 1"
+
+
+def test_unblock_result_with_all_fields():
+    result = UnblockResult(
+        success=True,
+        actions_log=["created fix ticket"],
+        escalated=True,
+        replacement_task_id="M5-01",
+        skip_to_next=True,
+        alternative_model="gemini",
+    )
+
+    assert result.success is True
+    assert result.escalated is True
+    assert result.replacement_task_id == "M5-01"
+    assert result.skip_to_next is True
+    assert result.alternative_model == "gemini"
+
+
+class TestMergeConflictStrategy:
+    def test_merge_conflict_strategy_resets_and_reapplies(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+        branch_manager.verify_ssh_remote = MagicMock()
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        ai_runner.run_coder = MagicMock(return_value=True)
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.MERGE_CONFLICT,
+            task_id="M4-01",
+            context="merge conflict in ralph.py",
+        )
+        task = {
+            "id": "M4-01",
+            "title": "Test Task",
+            "description": "Test description",
+            "acceptance_criteria": ["Test AC"],
+        }
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is True
+        assert len(result.actions_log) > 0
+        assert any("merge conflict" in log.lower() for log in result.actions_log)
+        assert any("reset" in log.lower() for log in result.actions_log)
+        assert any(
+            "re-apply" in log.lower() or "coder" in log.lower() for log in result.actions_log
+        )
+
+    def test_merge_conflict_strategy_fails_gracefully(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.runner.run = MagicMock(side_effect=Exception("git failed"))
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+        branch_manager.verify_ssh_remote = MagicMock()
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.MERGE_CONFLICT,
+            task_id="M4-01",
+            context="merge conflict",
+        )
+        task = {"id": "M4-01", "title": "Test Task", "description": "Desc"}
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is False
+        assert result.escalated is True
+
+
+class TestCIFatalStrategy:
+    def test_ci_fatal_creates_fix_ticket_via_backlog_manager(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.runner.run = MagicMock(return_value=MagicMock(stdout="Issue created #42"))
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.CI_FATAL,
+            task_id="M4-02",
+            context="CI failed: tests failed after 2 fix rounds",
+        )
+        task = {
+            "id": "M4-02",
+            "title": "Test CI Task",
+            "description": "Test CI description",
+            "acceptance_criteria": ["Tests pass"],
+        }
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is True
+        assert result.skip_to_next is True
+        assert len(result.actions_log) > 0
+        assert any("ci" in log.lower() for log in result.actions_log)
+        assert any("ticket" in log.lower() or "fix" in log.lower() for log in result.actions_log)
+        assert any("skip" in log.lower() for log in result.actions_log)
+
+    def test_ci_fatal_handles_ticket_creation_failure(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.runner.run = MagicMock(side_effect=Exception("gh failed"))
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.CI_FATAL,
+            task_id="M4-02",
+            context="CI failed",
+        )
+        task = {"id": "M4-02", "title": "Test Task", "description": "Desc"}
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is False
+        assert result.skip_to_next is True
+        assert result.escalated is True
+
+
+class TestPRDGuardViolationStrategy:
+    def test_prd_guard_rolls_back_and_escalates(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        pr_manager.close = MagicMock()
+
+        task_tracker = MagicMock()
+        task_tracker.add_task = MagicMock()
+
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.PRD_GUARD_VIOLATION,
+            task_id="M4-03",
+            context="prd.json was modified by coder",
+        )
+        task = {
+            "id": "M4-03",
+            "title": "Test PRD Task",
+            "description": "Test PRD guard violation task",
+            "acceptance_criteria": ["AC 1"],
+            "owner": "ralph",
+            "completed": False,
+            "depends_on": [],
+            "epic": "M4",
+            "pr_number": 123,
+        }
+        prd = {"tasks": [{"id": "M4-01", "title": "Existing Task"}]}
+
+        result = strategy.execute(blocker, task, prd)
+
+        assert result.success is True
+        assert result.escalated is True
+        assert result.replacement_task_id is not None
+        assert len(result.actions_log) > 0
+        assert any("prd" in log.lower() or "guard" in log.lower() for log in result.actions_log)
+        assert any(
+            "rollback" in log.lower() or "close" in log.lower() for log in result.actions_log
+        )
+        assert any(
+            "replacement" in log.lower() or "review" in log.lower() for log in result.actions_log
+        )
+        task_tracker.add_task.assert_called_once()
+
+    def test_prd_guard_creates_replacement_task(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        pr_manager.close = MagicMock()
+
+        task_tracker = MagicMock()
+        task_tracker.add_task = MagicMock()
+
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.PRD_GUARD_VIOLATION,
+            task_id="M4-03",
+            context="prd.json modified",
+        )
+        task = {
+            "id": "M4-03",
+            "title": "Original Task",
+            "description": "Original description",
+            "acceptance_criteria": ["Test AC"],
+            "owner": "ralph",
+            "completed": False,
+            "depends_on": [],
+            "epic": "M4",
+        }
+        prd = {"tasks": []}
+
+        result = strategy.execute(blocker, task, prd)
+
+        assert result.replacement_task_id is not None
+        assert "-FIX" in result.replacement_task_id
+        task_tracker.add_task.assert_called_once()
+
+
+class TestReviewerUnavailableStrategy:
+    def test_reviewer_unavailable_switches_model(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=BlockerKind.REVIEWER_UNAVAILABLE,
+            task_id="M4-04",
+            context="Reviewer claude returned no output",
+        )
+        task = {
+            "id": "M4-04",
+            "title": "Test Reviewer Task",
+            "description": "Test reviewer unavailable task",
+            "acceptance_criteria": ["AC 1"],
+        }
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is True
+        assert result.alternative_model is not None
+        assert result.alternative_model in ["gemini", "claude", "opencode"]
+        assert len(result.actions_log) > 0
+        assert any("reviewer" in log.lower() for log in result.actions_log)
+        assert any(
+            "alternative" in log.lower() or "switch" in log.lower() for log in result.actions_log
+        )
+
+
+class TestUnknownBlockerKind:
+    def test_unknown_blocker_kind_escalates(self):
+        branch_manager = MagicMock()
+        branch_manager.repo_dir = MagicMock()
+        branch_manager.runner = MagicMock()
+        branch_manager.sanitise_branch_name = MagicMock(return_value="test-task")
+
+        pr_manager = MagicMock()
+        task_tracker = MagicMock()
+        ai_runner = MagicMock()
+        logger = MagicMock()
+
+        strategy = UnblockStrategy(
+            branch_manager=branch_manager,
+            pr_manager=pr_manager,
+            task_tracker=task_tracker,
+            ai_runner=ai_runner,
+            logger=logger,
+        )
+
+        blocker = BlockerResult(
+            kind=MagicMock(),  # Unknown kind - not matching any enum
+            task_id="M4-05",
+            context="Unknown error",
+        )
+        task = {"id": "M4-05", "title": "Test Task", "description": "Desc"}
+
+        result = strategy.execute(blocker, task, {})
+
+        assert result.success is False
+        assert result.escalated is True


### PR DESCRIPTION
## [M4-03] unblockstrategy_per_blocker_recovery

**Epic:** M4
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement UnblockStrategy class that provides specific recovery tactics for each BlockerKind variant. For MERGE_CONFLICT: abort merge, reset branch, and re-apply changes. For CI_FATAL: create FIX ticket with failure context and skip to next task. For PRD_GUARD_VIOLATION: rollback PR, mark task for human review, create replacement task. For REVIEWER_UNAVAILABLE: switch to alternative reviewer model or enable skip-review mode. Each strategy must log actions taken and return success/failure status for escalation decisions.

### Acceptance Criteria
['tests/test_unblock_strategy.py: test_merge_conflict_strategy_resets_and_reapplies', 'tests/test_unblock_strategy.py: test_ci_fatal_creates_fix_ticket_via_backlog_manager', 'tests/test_unblock_strategy.py: test_prd_guard_rolls_back_and_escalates', 'tests/test_unblock_strategy.py: test_reviewer_unavailable_switches_model', 'ralph.py: UnblockStrategy class with execute() method per BlockerKind']

---
*Ralph Loop — multi-agent AI pair programming*