### PR TITLE
[M5-02] wave_executor_parallel_runner

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -14,6 +14,7 @@ Run with --help for full option list.
 """
 
 import ast
+import asyncio
 import enum
 import json
 import os
@@ -21,6 +22,7 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -324,6 +326,7 @@ class Config:
     gemini_only: bool = False
     opencode_only: bool = False
     validate_plan: bool = False  # Tier 2 AI sanity check on prd.json
+    max_workers: int | None = None  # WaveExecutor parallelism cap (None = CPU count)
 
 
 @dataclass
@@ -366,6 +369,151 @@ class BranchStatus:
 class TaskResult:
     fatal: bool
     message: str = ""
+
+
+@dataclass
+class ExecutionReport:
+    """Summary of a parallel wave execution run."""
+
+    results: dict[str, TaskResult]  # task_id -> TaskResult
+    waves_run: int
+    tasks_blocked: list[str] = field(default_factory=list)  # IDs skipped due to failed deps
+
+
+class WaveExecutor:
+    """Executes tasks in dependency-ordered waves with asyncio concurrency.
+
+    Uses DependencyGraph to group tasks into waves where all dependencies of
+    every task in a wave are satisfied by earlier waves.  Tasks within a wave
+    are run concurrently via asyncio.gather(); a semaphore caps parallelism to
+    max_workers.
+
+    A task_runner callable is injected at construction time so that the class
+    is fully unit-testable without touching real git / AI infrastructure.  The
+    runner may be a plain sync function or an async coroutine function — both
+    are supported.
+    """
+
+    def __init__(
+        self,
+        tasks: list[dict],
+        task_runner: Callable[[str], TaskResult] | None = None,
+        max_workers: int | None = None,
+    ) -> None:
+        self._tasks: dict[str, dict] = {t["id"]: t for t in tasks}
+        self._graph = DependencyGraph()
+        self._graph.build_graph(tasks)
+        self._task_runner: Callable[[str], TaskResult] = task_runner or self._default_runner
+        self._max_workers: int = max_workers or os.cpu_count() or 4
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build_waves(self, task_ids: list[str]) -> list[list[str]]:
+        """Group task_ids into sequentially-ordered waves.
+
+        Wave 0 contains tasks with no intra-list dependencies.  Wave N
+        contains tasks whose dependencies are all satisfied by waves < N.
+        Dependencies on task IDs *outside* task_ids are treated as already
+        satisfied (completed externally).
+        """
+        task_id_set = set(task_ids)
+        completed: set[str] = set()
+        remaining = list(task_ids)
+        waves: list[list[str]] = []
+
+        while remaining:
+            ready = sorted(
+                tid
+                for tid in remaining
+                if all(
+                    dep not in task_id_set or dep in completed
+                    for dep in self._tasks.get(tid, {}).get("depends_on", [])
+                )
+            )
+            if not ready:
+                # Unresolvable subset (cycle or missing deps) — emit as a
+                # final wave so callers get all task IDs back.
+                waves.append(sorted(remaining))
+                break
+            waves.append(ready)
+            completed.update(ready)
+            remaining = [tid for tid in remaining if tid not in set(ready)]
+
+        return waves
+
+    def execute_wave(self, wave: list[str]) -> dict[str, TaskResult]:
+        """Run all tasks in *wave* concurrently and return their results.
+
+        Uses asyncio.gather() with a semaphore capped at max_workers.
+        """
+        return asyncio.run(self._execute_wave_async(wave))
+
+    def run_parallel(self, tasks: list[dict]) -> ExecutionReport:
+        """Execute all tasks across dependency-ordered waves.
+
+        Failed tasks in a wave do not prevent other tasks in that wave from
+        running, but they block any dependent tasks in future waves.
+        """
+        task_ids = [t["id"] for t in tasks]
+        waves = self.build_waves(task_ids)
+        all_results: dict[str, TaskResult] = {}
+        failed_ids: set[str] = set()
+        blocked_ids: list[str] = []
+
+        for wave in waves:
+            runnable: list[str] = []
+            for tid in wave:
+                deps = self._tasks.get(tid, {}).get("depends_on", [])
+                if any(dep in failed_ids for dep in deps):
+                    blocked_ids.append(tid)
+                    all_results[tid] = TaskResult(fatal=True, message="blocked: dependency failed")
+                else:
+                    runnable.append(tid)
+
+            # Blocked tasks are also failures for dependency propagation
+            failed_ids.update(blocked_ids)
+
+            if runnable:
+                wave_results = self.execute_wave(runnable)
+                all_results.update(wave_results)
+                for tid, result in wave_results.items():
+                    if result.fatal:
+                        failed_ids.add(tid)
+
+        return ExecutionReport(
+            results=all_results,
+            waves_run=len(waves),
+            tasks_blocked=blocked_ids,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _default_runner(task_id: str) -> TaskResult:  # pragma: no cover
+        """Placeholder runner — callers should inject a real runner."""
+        return TaskResult(fatal=False, message=f"noop:{task_id}")
+
+    async def _execute_wave_async(self, wave: list[str]) -> dict[str, TaskResult]:
+        semaphore = asyncio.Semaphore(self._max_workers)
+        coros = [self._run_with_semaphore(tid, semaphore) for tid in wave]
+        pairs = await asyncio.gather(*coros)
+        return dict(pairs)
+
+    async def _run_with_semaphore(
+        self, task_id: str, semaphore: asyncio.Semaphore
+    ) -> tuple[str, TaskResult]:
+        async with semaphore:
+            runner = self._task_runner
+            if asyncio.iscoroutinefunction(runner):
+                result = await runner(task_id)
+            else:
+                loop = asyncio.get_event_loop()
+                result = await loop.run_in_executor(None, runner, task_id)
+            return task_id, result
 
 
 @dataclass
@@ -4231,6 +4379,13 @@ def cli():
     default=None,
     help="Repo root (default: directory containing ralph.py)",
 )
+@click.option(
+    "--max-workers",
+    "max_workers",
+    default=None,
+    type=int,
+    help="Max parallel tasks in a wave (default: CPU count)",
+)
 def run(
     max_iterations: int,
     skip_review: bool,
@@ -4248,6 +4403,7 @@ def run(
     deep_review_check: bool,
     dry_run: bool,
     repo_dir: Path | None,
+    max_workers: int | None,
 ) -> int:
     """Run the AI sprint loop."""
     if repo_dir is None:
@@ -4275,6 +4431,7 @@ def run(
         gemini_only=gemini_only,
         opencode_only=opencode_only,
         validate_plan=validate_plan,
+        max_workers=max_workers,
     )
 
     logger = RalphLogger(log_file)

--- a/tests/test_wave_executor.py
+++ b/tests/test_wave_executor.py
@@ -1,0 +1,294 @@
+"""Tests for WaveExecutor — wave-based parallel task runner."""
+
+import asyncio
+
+from ralph import ExecutionReport, TaskResult, WaveExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_task(task_id: str, depends_on: list[str] | None = None) -> dict:
+    return {"id": task_id, "depends_on": depends_on or []}
+
+
+def ok_runner(task_id: str) -> TaskResult:
+    return TaskResult(fatal=False, message=f"ok:{task_id}")
+
+
+def fail_runner(task_id: str) -> TaskResult:
+    return TaskResult(fatal=True, message=f"fail:{task_id}")
+
+
+# ---------------------------------------------------------------------------
+# build_waves — grouping
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWaves:
+    def test_independent_tasks_same_wave(self):
+        tasks = [make_task("A"), make_task("B"), make_task("C")]
+        executor = WaveExecutor(tasks)
+        waves = executor.build_waves(["A", "B", "C"])
+        assert len(waves) == 1
+        assert set(waves[0]) == {"A", "B", "C"}
+
+    def test_dependent_tasks_sequential_waves(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks)
+        waves = executor.build_waves(["A", "B"])
+        assert len(waves) == 2
+        assert "A" in waves[0]
+        assert "B" in waves[1]
+
+    def test_linear_chain_three_waves(self):
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C", ["B"])]
+        executor = WaveExecutor(tasks)
+        waves = executor.build_waves(["A", "B", "C"])
+        assert len(waves) == 3
+        assert waves[0] == ["A"]
+        assert waves[1] == ["B"]
+        assert waves[2] == ["C"]
+
+    def test_diamond_two_waves(self):
+        """A → B, A → C: A in wave 0, B+C in wave 1."""
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C", ["A"])]
+        executor = WaveExecutor(tasks)
+        waves = executor.build_waves(["A", "B", "C"])
+        assert len(waves) == 2
+        assert waves[0] == ["A"]
+        assert set(waves[1]) == {"B", "C"}
+
+    def test_external_dependency_treated_as_satisfied(self):
+        """Dep on a task outside task_ids — treated as already done."""
+        tasks = [make_task("B", ["EXTERNAL"]), make_task("A")]
+        executor = WaveExecutor(tasks)
+        # EXTERNAL is not in the provided list, so B can be in wave 0
+        waves = executor.build_waves(["A", "B"])
+        assert len(waves) == 1
+        assert set(waves[0]) == {"A", "B"}
+
+    def test_empty_task_list(self):
+        executor = WaveExecutor([])
+        assert executor.build_waves([]) == []
+
+    def test_single_task_one_wave(self):
+        executor = WaveExecutor([make_task("X")])
+        waves = executor.build_waves(["X"])
+        assert waves == [["X"]]
+
+    def test_wave_ordering_is_deterministic(self):
+        """build_waves output is sorted — same input always same output."""
+        tasks = [make_task("Z"), make_task("A"), make_task("M")]
+        executor = WaveExecutor(tasks)
+        waves1 = executor.build_waves(["Z", "A", "M"])
+        waves2 = executor.build_waves(["M", "Z", "A"])
+        assert waves1 == waves2
+        assert waves1[0] == ["A", "M", "Z"]
+
+
+# ---------------------------------------------------------------------------
+# execute_wave — asyncio concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWave:
+    def test_returns_result_for_each_task(self):
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        results = executor.execute_wave(["A", "B"])
+        assert set(results.keys()) == {"A", "B"}
+
+    def test_successful_tasks_not_fatal(self):
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        results = executor.execute_wave(["A", "B"])
+        assert not results["A"].fatal
+        assert not results["B"].fatal
+
+    def test_failed_task_marked_fatal(self):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        results = executor.execute_wave(["A"])
+        assert results["A"].fatal
+
+    def test_runs_tasks_concurrently_using_asyncio(self):
+        """Verify asyncio concurrency: tasks run in parallel, not sequentially."""
+        import time
+
+        started: list[float] = []
+
+        async def slow_runner(task_id: str) -> TaskResult:
+            started.append(time.monotonic())
+            await asyncio.sleep(0.05)
+            return TaskResult(fatal=False, message=task_id)
+
+        tasks = [make_task("A"), make_task("B"), make_task("C")]
+        executor = WaveExecutor(tasks, task_runner=slow_runner, max_workers=3)
+        t0 = time.monotonic()
+        results = executor.execute_wave(["A", "B", "C"])
+        elapsed = time.monotonic() - t0
+        # Parallel: all 3 tasks sleep 0.05s concurrently → total ≈ 0.05s
+        # Sequential would take ≈ 0.15s.  Allow generous headroom.
+        assert elapsed < 0.12, f"expected parallel execution, got {elapsed:.3f}s"
+        assert set(results.keys()) == {"A", "B", "C"}
+
+    def test_async_runner_is_supported(self):
+        async def async_ok(task_id: str) -> TaskResult:
+            await asyncio.sleep(0)
+            return TaskResult(fatal=False, message=f"async:{task_id}")
+
+        tasks = [make_task("X")]
+        executor = WaveExecutor(tasks, task_runner=async_ok)
+        results = executor.execute_wave(["X"])
+        assert results["X"].message == "async:X"
+
+    def test_empty_wave_returns_empty_dict(self):
+        executor = WaveExecutor([])
+        results = executor.execute_wave([])
+        assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# max_workers — limits concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestMaxWorkers:
+    def test_max_workers_limits_concurrency(self):
+        """At most max_workers tasks run at the same time."""
+        max_concurrent: list[int] = [0]
+        active: list[int] = [0]
+
+        async def counting_runner(task_id: str) -> TaskResult:
+            active[0] += 1
+            max_concurrent[0] = max(max_concurrent[0], active[0])
+            await asyncio.sleep(0.02)
+            active[0] -= 1
+            return TaskResult(fatal=False, message=task_id)
+
+        n_tasks = 6
+        limit = 2
+        tasks = [make_task(str(i)) for i in range(n_tasks)]
+        executor = WaveExecutor(tasks, task_runner=counting_runner, max_workers=limit)
+        executor.execute_wave([str(i) for i in range(n_tasks)])
+        assert max_concurrent[0] <= limit
+
+    def test_max_workers_one_serialises(self):
+        """max_workers=1 → serial execution."""
+        order: list[str] = []
+
+        async def ordered_runner(task_id: str) -> TaskResult:
+            order.append(f"start:{task_id}")
+            await asyncio.sleep(0.01)
+            order.append(f"end:{task_id}")
+            return TaskResult(fatal=False, message=task_id)
+
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ordered_runner, max_workers=1)
+        executor.execute_wave(["A", "B"])
+        # With max_workers=1 each task completes before the next starts
+        starts = [e for e in order if e.startswith("start:")]
+        ends = [e for e in order if e.startswith("end:")]
+        assert len(starts) == 2
+        assert len(ends) == 2
+        # first task must end before second task starts
+        assert order.index("end:" + starts[0][6:]) < order.index(starts[1])
+
+
+# ---------------------------------------------------------------------------
+# ExecutionReport
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionReport:
+    def test_report_contains_all_task_results(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert isinstance(report, ExecutionReport)
+        assert set(report.results.keys()) == {"A", "B"}
+
+    def test_report_waves_run_count(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert report.waves_run == 2
+
+    def test_report_tasks_blocked_empty_on_success(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert report.tasks_blocked == []
+
+    def test_per_task_success_status(self):
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert not report.results["A"].fatal
+        assert not report.results["B"].fatal
+
+    def test_per_task_failure_status(self):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        report = executor.run_parallel(tasks)
+        assert report.results["A"].fatal
+
+
+# ---------------------------------------------------------------------------
+# Failed tasks block dependents
+# ---------------------------------------------------------------------------
+
+
+class TestFailureBlocking:
+    def test_failed_task_blocks_dependent_in_next_wave(self):
+        """A fails → B (depends on A) is blocked, not executed."""
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        report = executor.run_parallel(tasks)
+        assert report.results["A"].fatal
+        assert report.results["B"].fatal
+        assert "B" in report.tasks_blocked
+
+    def test_failed_task_does_not_block_independent_sibling(self):
+        """A fails; C (independent) still runs successfully."""
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C")]
+
+        def selective_runner(task_id: str) -> TaskResult:
+            if task_id == "A":
+                return TaskResult(fatal=True, message="fail")
+            return TaskResult(fatal=False, message="ok")
+
+        executor = WaveExecutor(tasks, task_runner=selective_runner)
+        report = executor.run_parallel(tasks)
+        assert report.results["A"].fatal
+        assert "B" in report.tasks_blocked
+        assert not report.results["C"].fatal
+
+    def test_transitive_blocking(self):
+        """A → B → C: A fails → B blocked → C blocked."""
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C", ["B"])]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        report = executor.run_parallel(tasks)
+        assert report.results["A"].fatal
+        assert "B" in report.tasks_blocked
+        assert "C" in report.tasks_blocked
+
+    def test_wave_continues_despite_peer_failure(self):
+        """In a wave with A and B, B's failure doesn't prevent A from completing."""
+        tasks = [make_task("A"), make_task("B")]
+        call_order: list[str] = []
+
+        def tracking_runner(task_id: str) -> TaskResult:
+            call_order.append(task_id)
+            if task_id == "B":
+                return TaskResult(fatal=True, message="fail")
+            return TaskResult(fatal=False, message="ok")
+
+        executor = WaveExecutor(tasks, task_runner=tracking_runner)
+        report = executor.run_parallel(tasks)
+        assert "A" in call_order
+        assert "B" in call_order
+        assert not report.results["A"].fatal
+        assert report.results["B"].fatal


### PR DESCRIPTION
## [M5-02] wave_executor_parallel_runner

**Epic:** M5
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement a wave-based parallel executor in `ralph.py` that groups tasks into waves based on dependency readiness and executes them concurrently. Create a `WaveExecutor` class that uses the DependencyGraph from M5-01 to: (1) group tasks with satisfied dependencies into waves where no task depends on another in the same wave, (2) run each wave using `asyncio.gather()` or `multiprocessing.Pool` (default to asyncio for lower overhead), (3) track task results and propagate failures. Methods: `build_waves(task_ids: list[str]) -> list[list[str]]` (returns waves of task IDs), `execute_wave(wave: list[str]) -> dict[str, TaskResult]`, and `run_parallel(tasks: list[dict]) -> ExecutionReport`. Each task execution should be isolated — it spawns a subprocess or async task that runs the existing task execution logic. Limit parallelism with `--max-workers` flag (default: CPU count). Task failures in a wave should not prevent other wave tasks from completing, but failed tasks block dependent tasks in future waves.

### Acceptance Criteria
['tests/test_wave_executor.py: build_waves() groups independent tasks into same wave', 'tests/test_wave_executor.py: build_waves() places dependent tasks in sequential waves', 'tests/test_wave_executor.py: execute_wave() runs tasks concurrently using asyncio', 'tests/test_wave_executor.py: --max-workers flag limits concurrent execution', 'tests/test_wave_executor.py: ExecutionReport contains per-task success/failure status', 'tests/test_wave_executor.py: failed tasks block dependents in subsequent waves']

---
*Ralph Loop — multi-agent AI pair programming*