### PR TITLE
[M5-04] conflict_detection_file_overlap

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -126,6 +126,12 @@ class PlanInvalidError(RalphError):
     pass
 
 
+class WaveConflictError(RalphError):
+    """A wave contains tasks that share files — would cause a race condition."""
+
+    pass
+
+
 class PrdValidator:
     """Shared validation layer for prd.json tasks.
 
@@ -382,6 +388,61 @@ class ExecutionReport:
     tasks_blocked: list[str] = field(default_factory=list)  # IDs skipped due to failed deps
 
 
+@dataclass
+class ConflictReport:
+    """Result of a pre-wave file-overlap conflict check."""
+
+    has_conflicts: bool
+    conflicting_tasks: list[tuple[str, str]]  # pairs of task IDs that share a file
+    shared_files: dict[str, list[str]]  # file path -> list of task IDs that claim it
+
+
+class ConflictDetector:
+    """Detects file-overlap conflicts between tasks that would run in the same wave.
+
+    Two tasks conflict when they both list the same path in their ``files`` field.
+    Running them concurrently risks race conditions where both agents modify the
+    same file simultaneously.
+    """
+
+    def check_wave_conflicts(self, tasks: list[dict]) -> ConflictReport:
+        """Analyse *tasks* for file-path overlaps.
+
+        Args:
+            tasks: List of task dicts, each optionally containing a ``files``
+                   key with a list of file paths.
+
+        Returns:
+            A :class:`ConflictReport` describing any overlaps found.
+        """
+        # Build a map: file_path -> [task_ids that claim it]
+        file_to_tasks: dict[str, list[str]] = {}
+        for task in tasks:
+            task_id = task["id"]
+            for path in task.get("files", []):
+                file_to_tasks.setdefault(path, []).append(task_id)
+
+        # Keep only files claimed by more than one task
+        shared_files = {p: ids for p, ids in file_to_tasks.items() if len(ids) > 1}
+
+        # Collect unique conflicting pairs (ordered so tests are deterministic)
+        seen: set[tuple[str, str]] = set()
+        conflicting_tasks: list[tuple[str, str]] = []
+        for ids in shared_files.values():
+            for i in range(len(ids)):
+                for j in range(i + 1, len(ids)):
+                    pair = (ids[i], ids[j])
+                    if pair not in seen:
+                        seen.add(pair)
+                        conflicting_tasks.append(pair)
+
+        return ConflictReport(
+            has_conflicts=bool(shared_files),
+            conflicting_tasks=conflicting_tasks,
+            shared_files=shared_files,
+        )
+
+
 class WaveExecutor:
     """Executes tasks in dependency-ordered waves with asyncio concurrency.
 
@@ -407,6 +468,7 @@ class WaveExecutor:
         self._graph.build_graph(tasks)
         self._task_runner: Callable[[str], TaskResult] = task_runner or self._default_runner
         self._max_workers: int = max_workers or os.cpu_count() or 4
+        self._conflict_detector = ConflictDetector()
 
     # ------------------------------------------------------------------
     # Public API
@@ -419,6 +481,9 @@ class WaveExecutor:
         contains tasks whose dependencies are all satisfied by waves < N.
         Dependencies on task IDs *outside* task_ids are treated as already
         satisfied (completed externally).
+
+        Within each dependency wave, tasks that share files are split into
+        separate sub-waves to prevent parallel file-modification race conditions.
         """
         task_id_set = set(task_ids)
         completed: set[str] = set()
@@ -437,19 +502,66 @@ class WaveExecutor:
             if not ready:
                 # Unresolvable subset (cycle or missing deps) — emit as a
                 # final wave so callers get all task IDs back.
-                waves.append(sorted(remaining))
+                waves.extend(self._split_conflicting([tid for tid in sorted(remaining)]))
                 break
-            waves.append(ready)
+            waves.extend(self._split_conflicting(ready))
             completed.update(ready)
             remaining = [tid for tid in remaining if tid not in set(ready)]
 
         return waves
 
+    def _split_conflicting(self, task_ids: list[str]) -> list[list[str]]:
+        """Split *task_ids* into sub-waves so no two conflicting tasks share a wave.
+
+        Uses a greedy graph-colouring approach: assign each task (in sorted
+        order) to the first existing sub-wave that contains none of its
+        conflicting peers.  Returns a list of sub-waves (each a sorted list).
+        """
+        tasks = [self._tasks[tid] for tid in task_ids if tid in self._tasks]
+        # Include tasks not in self._tasks (e.g. external deps) as file-less stubs
+        task_map = {tid: self._tasks.get(tid, {"id": tid}) for tid in task_ids}
+        tasks = [task_map[tid] for tid in task_ids]
+
+        report = self._conflict_detector.check_wave_conflicts(tasks)
+        if not report.has_conflicts:
+            return [task_ids]
+
+        # Build adjacency set: task_id -> set of task_ids it conflicts with
+        conflicts: dict[str, set[str]] = {tid: set() for tid in task_ids}
+        for a, b in report.conflicting_tasks:
+            conflicts[a].add(b)
+            conflicts[b].add(a)
+
+        sub_waves: list[list[str]] = []
+        for tid in task_ids:
+            placed = False
+            for sub_wave in sub_waves:
+                if not any(peer in conflicts[tid] for peer in sub_wave):
+                    sub_wave.append(tid)
+                    placed = True
+                    break
+            if not placed:
+                sub_waves.append([tid])
+
+        return sub_waves
+
     def execute_wave(self, wave: list[str]) -> dict[str, TaskResult]:
         """Run all tasks in *wave* concurrently and return their results.
 
         Uses asyncio.gather() with a semaphore capped at max_workers.
+
+        Raises:
+            WaveConflictError: if any two tasks in *wave* share a file path,
+                which would risk a parallel file-modification race condition.
         """
+        wave_tasks = [self._tasks[tid] for tid in wave if tid in self._tasks]
+        report = self._conflict_detector.check_wave_conflicts(wave_tasks)
+        if report.has_conflicts:
+            pairs = ", ".join(f"({a}, {b})" for a, b in report.conflicting_tasks)
+            raise WaveConflictError(
+                f"wave contains tasks with overlapping files — would cause race conditions. "
+                f"Conflicting pairs: {pairs}"
+            )
         return asyncio.run(self._execute_wave_async(wave))
 
     def run_parallel(self, tasks: list[dict]) -> ExecutionReport:

--- a/tests/test_conflict_detector.py
+++ b/tests/test_conflict_detector.py
@@ -1,0 +1,259 @@
+"""Tests for ConflictDetector and its integration with WaveExecutor."""
+
+import pytest
+
+from ralph import ConflictDetector, ConflictReport, TaskResult, WaveConflictError, WaveExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_task(
+    task_id: str, files: list[str] | None = None, depends_on: list[str] | None = None
+) -> dict:
+    t: dict = {"id": task_id, "depends_on": depends_on or []}
+    if files is not None:
+        t["files"] = files
+    return t
+
+
+def ok_runner(task_id: str) -> TaskResult:
+    return TaskResult(fatal=False, message=f"ok:{task_id}")
+
+
+# ---------------------------------------------------------------------------
+# ConflictDetector.check_wave_conflicts — basic detection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWaveConflicts:
+    def test_no_conflicts_disjoint_files(self):
+        tasks = [
+            make_task("A", files=["src/foo.py"]),
+            make_task("B", files=["src/bar.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert isinstance(report, ConflictReport)
+        assert not report.has_conflicts
+        assert report.conflicting_tasks == []
+        assert report.shared_files == {}
+
+    def test_no_conflicts_empty_files(self):
+        tasks = [make_task("A"), make_task("B")]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert not report.has_conflicts
+
+    def test_no_conflicts_single_task(self):
+        tasks = [make_task("A", files=["src/foo.py"])]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert not report.has_conflicts
+
+    def test_detects_shared_file(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert report.has_conflicts
+
+    def test_shared_files_maps_file_to_task_ids(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert "src/shared.py" in report.shared_files
+        assert set(report.shared_files["src/shared.py"]) == {"A", "B"}
+
+    def test_conflicting_tasks_contains_correct_pair(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert len(report.conflicting_tasks) == 1
+        pair = report.conflicting_tasks[0]
+        assert set(pair) == {"A", "B"}
+
+    def test_multiple_shared_files(self):
+        tasks = [
+            make_task("A", files=["src/foo.py", "src/bar.py"]),
+            make_task("B", files=["src/foo.py"]),
+            make_task("C", files=["src/bar.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert report.has_conflicts
+        assert "src/foo.py" in report.shared_files
+        assert "src/bar.py" in report.shared_files
+
+    def test_three_tasks_sharing_one_file(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+            make_task("C", files=["src/shared.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert report.has_conflicts
+        # Three unique pairs: (A,B), (A,C), (B,C)
+        assert len(report.conflicting_tasks) == 3
+        pairs_as_sets = [frozenset(p) for p in report.conflicting_tasks]
+        assert frozenset({"A", "B"}) in pairs_as_sets
+        assert frozenset({"A", "C"}) in pairs_as_sets
+        assert frozenset({"B", "C"}) in pairs_as_sets
+
+    def test_no_duplicate_pairs(self):
+        """A file shared by A and B should produce exactly one pair, not two."""
+        tasks = [
+            make_task("A", files=["f.py", "g.py"]),
+            make_task("B", files=["f.py", "g.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        # Even though two files are shared, the pair (A, B) should appear once
+        pairs_as_sets = [frozenset(p) for p in report.conflicting_tasks]
+        assert pairs_as_sets.count(frozenset({"A", "B"})) == 1
+
+    def test_empty_task_list(self):
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts([])
+        assert not report.has_conflicts
+        assert report.conflicting_tasks == []
+        assert report.shared_files == {}
+
+    def test_non_overlapping_mix(self):
+        tasks = [
+            make_task("A", files=["src/a.py"]),
+            make_task("B", files=["src/b.py"]),
+            make_task("C", files=["src/c.py", "src/a.py"]),
+        ]
+        detector = ConflictDetector()
+        report = detector.check_wave_conflicts(tasks)
+        assert report.has_conflicts
+        assert set(report.shared_files["src/a.py"]) == {"A", "C"}
+        # B is not involved in any conflict
+        all_task_ids = {tid for pair in report.conflicting_tasks for tid in pair}
+        assert "B" not in all_task_ids
+
+
+# ---------------------------------------------------------------------------
+# WaveExecutor.build_waves — conflict-aware splitting
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWavesConflictSplitting:
+    def test_conflicting_tasks_placed_in_separate_waves(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        waves = executor.build_waves(["A", "B"])
+        # A and B must NOT be in the same wave
+        for wave in waves:
+            assert not ({"A", "B"} <= set(wave)), "A and B share a file — must be in separate waves"
+        # Both tasks appear exactly once across all waves
+        all_ids = [tid for wave in waves for tid in wave]
+        assert sorted(all_ids) == ["A", "B"]
+
+    def test_non_conflicting_tasks_stay_in_same_wave(self):
+        tasks = [
+            make_task("A", files=["src/a.py"]),
+            make_task("B", files=["src/b.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        waves = executor.build_waves(["A", "B"])
+        assert len(waves) == 1
+        assert set(waves[0]) == {"A", "B"}
+
+    def test_three_tasks_all_conflicting_three_waves(self):
+        """A, B, C all share the same file — each in its own wave."""
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+            make_task("C", files=["src/shared.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        waves = executor.build_waves(["A", "B", "C"])
+        for wave in waves:
+            assert len(wave) == 1, "all three conflict — each must be alone in its wave"
+
+    def test_partial_conflict_splits_only_conflicting_pair(self):
+        """A and B conflict; C is independent — C can share a wave with A or B."""
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+            make_task("C", files=["src/c.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        waves = executor.build_waves(["A", "B", "C"])
+        for wave in waves:
+            assert not ({"A", "B"} <= set(wave)), "A and B must not be in the same wave"
+        all_ids = sorted(tid for wave in waves for tid in wave)
+        assert all_ids == ["A", "B", "C"]
+
+    def test_dependency_then_conflict(self):
+        """C depends on A; A and B conflict. A→wave0 (split from B), B→wave0 or 1, C→after A."""
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+            make_task("C", depends_on=["A"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        waves = executor.build_waves(["A", "B", "C"])
+        # A and B must never be in the same wave
+        for wave in waves:
+            assert not ({"A", "B"} <= set(wave))
+        # C must appear after A
+        wave_for = {tid: i for i, wave in enumerate(waves) for tid in wave}
+        assert wave_for["C"] > wave_for["A"]
+        all_ids = sorted(tid for wave in waves for tid in wave)
+        assert all_ids == ["A", "B", "C"]
+
+
+# ---------------------------------------------------------------------------
+# WaveExecutor.execute_wave — raises WaveConflictError
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWaveConflictGuard:
+    def test_raises_on_conflicting_wave(self):
+        tasks = [
+            make_task("A", files=["src/shared.py"]),
+            make_task("B", files=["src/shared.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        with pytest.raises(WaveConflictError):
+            executor.execute_wave(["A", "B"])
+
+    def test_no_error_for_disjoint_files(self):
+        tasks = [
+            make_task("A", files=["src/a.py"]),
+            make_task("B", files=["src/b.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        results = executor.execute_wave(["A", "B"])
+        assert set(results.keys()) == {"A", "B"}
+
+    def test_no_error_for_tasks_without_files(self):
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        results = executor.execute_wave(["A", "B"])
+        assert set(results.keys()) == {"A", "B"}
+
+    def test_error_message_contains_conflicting_pair(self):
+        tasks = [
+            make_task("X", files=["common.py"]),
+            make_task("Y", files=["common.py"]),
+        ]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        with pytest.raises(WaveConflictError, match="X"):
+            executor.execute_wave(["X", "Y"])


### PR DESCRIPTION
## [M5-04] conflict_detection_file_overlap

**Epic:** M5
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement pre-wave conflict detection in `ralph.py` to ensure tasks in the same wave don't share files in their `files` field. Create a `ConflictDetector` class that analyzes a set of tasks before they're grouped into a wave. Methods: `check_wave_conflicts(tasks: list[dict]) -> ConflictReport` where ConflictReport contains `has_conflicts: bool`, `conflicting_tasks: list[tuple[str, str]]` (pairs of task IDs that share files), and `shared_files: dict[str, list[str]]` (maps file path to task IDs). Two tasks conflict if they both list the same file path in their `files` field. Before executing any wave, run this check. If conflicts exist, the conflicting tasks must be split into separate waves (or the wave builder must ensure they're never in the same wave). This prevents race conditions where parallel tasks modify the same files. Integration: WaveExecutor.build_waves() should use ConflictDetector to verify waves are safe before execution.

### Acceptance Criteria
['tests/test_conflict_detector.py: check_wave_conflicts() returns no conflicts for tasks with disjoint files', 'tests/test_conflict_detector.py: detects when two tasks share a file in files field', 'tests/test_conflict_detector.py: ConflictReport contains correct conflicting task pairs', 'tests/test_conflict_detector.py: build_waves() places conflicting tasks in separate waves', 'tests/test_conflict_detector.py: error raised if wave with conflicts attempted execution']

---
*Ralph Loop — multi-agent AI pair programming*