### PR TITLE
[M5-06] wave_execution_summary

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -377,6 +377,19 @@ class BranchStatus:
 class TaskResult:
     fatal: bool
     message: str = ""
+    duration: float = 0.0
+
+
+@dataclass
+class WaveSummary:
+    """Per-wave execution summary stored in ExecutionReport.wave_histories."""
+
+    wave_number: int
+    total: int
+    succeeded: int
+    failed: int
+    skipped: int
+    results: dict[str, TaskResult]  # task_id -> TaskResult for all tasks in this wave
 
 
 @dataclass
@@ -386,6 +399,7 @@ class ExecutionReport:
     results: dict[str, TaskResult]  # task_id -> TaskResult
     waves_run: int
     tasks_blocked: list[str] = field(default_factory=list)  # IDs skipped due to failed deps
+    wave_histories: list[WaveSummary] = field(default_factory=list)  # per-wave summaries
 
 
 @dataclass
@@ -575,20 +589,24 @@ class WaveExecutor:
         all_results: dict[str, TaskResult] = {}
         failed_ids: set[str] = set()
         blocked_ids: list[str] = []
+        wave_histories: list[WaveSummary] = []
 
-        for wave in waves:
+        for wave_number, wave in enumerate(waves, start=1):
             runnable: list[str] = []
+            wave_skipped: list[str] = []
             for tid in wave:
                 deps = self._tasks.get(tid, {}).get("depends_on", [])
                 if any(dep in failed_ids for dep in deps):
                     blocked_ids.append(tid)
+                    wave_skipped.append(tid)
                     all_results[tid] = TaskResult(fatal=True, message="blocked: dependency failed")
                 else:
                     runnable.append(tid)
 
             # Blocked tasks are also failures for dependency propagation
-            failed_ids.update(blocked_ids)
+            failed_ids.update(wave_skipped)
 
+            wave_results: dict[str, TaskResult] = {}
             if runnable:
                 wave_results = self.execute_wave(runnable)
                 all_results.update(wave_results)
@@ -596,11 +614,74 @@ class WaveExecutor:
                     if result.fatal:
                         failed_ids.add(tid)
 
+            # Include skipped tasks in wave results for summary reporting
+            for tid in wave_skipped:
+                wave_results[tid] = all_results[tid]
+
+            self.print_wave_summary(wave_results, wave_number, wave_skipped)
+            succeeded = sum(1 for tid, r in wave_results.items() if not r.fatal)
+            failed = sum(
+                1 for tid, r in wave_results.items() if r.fatal and tid not in wave_skipped
+            )
+            wave_histories.append(
+                WaveSummary(
+                    wave_number=wave_number,
+                    total=len(wave),
+                    succeeded=succeeded,
+                    failed=failed,
+                    skipped=len(wave_skipped),
+                    results=dict(wave_results),
+                )
+            )
+
         return ExecutionReport(
             results=all_results,
             waves_run=len(waves),
             tasks_blocked=blocked_ids,
+            wave_histories=wave_histories,
         )
+
+    def print_wave_summary(
+        self,
+        wave_results: dict[str, TaskResult],
+        wave_number: int,
+        skipped_ids: list[str] | None = None,
+    ) -> None:
+        """Print a human-readable summary of a completed wave to stdout.
+
+        Args:
+            wave_results: Mapping of task_id -> TaskResult for all tasks in the wave.
+            wave_number:  1-based wave index.
+            skipped_ids:  Task IDs that were skipped due to dependency failures.
+        """
+        skipped_set = set(skipped_ids or [])
+        succeeded = [tid for tid, r in wave_results.items() if not r.fatal]
+        failed = [tid for tid, r in wave_results.items() if r.fatal and tid not in skipped_set]
+        skipped = [tid for tid in wave_results if tid in skipped_set]
+        total = len(wave_results)
+
+        header = click.style(f"── Wave {wave_number} complete ", fg="white", bold=True)
+        succeeded_txt = click.style(f"{len(succeeded)} succeeded", fg="green")
+        failed_txt = click.style(f"{len(failed)} failed", fg="red")
+        skipped_txt = click.style(f"{len(skipped)} skipped", fg="yellow")
+        click.echo(f"\n{header}({total} tasks: {succeeded_txt}, {failed_txt}, {skipped_txt})")
+
+        for tid in sorted(wave_results):
+            result = wave_results[tid]
+            duration_str = f"{result.duration:.1f}s"
+            if tid in skipped_set:
+                symbol = click.style("⊘", fg="yellow")
+                status = click.style("skipped", fg="yellow")
+                click.echo(f"  {symbol} {tid}  {status}  {duration_str}")
+            elif result.fatal:
+                symbol = click.style("✗", fg="red")
+                status = click.style("failed", fg="red")
+                err = f"  — {result.message}" if result.message else ""
+                click.echo(f"  {symbol} {tid}  {status}  {duration_str}{err}")
+            else:
+                symbol = click.style("✓", fg="green")
+                status = click.style("ok", fg="green")
+                click.echo(f"  {symbol} {tid}  {status}  {duration_str}")
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -622,11 +703,13 @@ class WaveExecutor:
     ) -> tuple[str, TaskResult]:
         async with semaphore:
             runner = self._task_runner
+            t0 = time.monotonic()
             if asyncio.iscoroutinefunction(runner):
                 result = await runner(task_id)
             else:
                 loop = asyncio.get_event_loop()
                 result = await loop.run_in_executor(None, runner, task_id)
+            result.duration = time.monotonic() - t0
             return task_id, result
 
 

--- a/tests/test_wave_summary.py
+++ b/tests/test_wave_summary.py
@@ -1,0 +1,276 @@
+"""Tests for WaveExecutor.print_wave_summary and ExecutionReport.wave_histories."""
+
+from unittest.mock import patch
+
+from ralph import TaskResult, WaveExecutor, WaveSummary
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_task(task_id: str, depends_on: list[str] | None = None) -> dict:
+    return {"id": task_id, "depends_on": depends_on or []}
+
+
+def ok_runner(task_id: str) -> TaskResult:
+    return TaskResult(fatal=False, message=f"ok:{task_id}")
+
+
+def fail_runner(task_id: str) -> TaskResult:
+    return TaskResult(fatal=True, message=f"fail:{task_id}")
+
+
+def selective_fail_runner(failing: set[str]):
+    def runner(task_id: str) -> TaskResult:
+        if task_id in failing:
+            return TaskResult(fatal=True, message=f"error in {task_id}")
+        return TaskResult(fatal=False, message=f"ok:{task_id}")
+
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# print_wave_summary — output format
+# ---------------------------------------------------------------------------
+
+
+class TestPrintWaveSummary:
+    """Unit tests for WaveExecutor.print_wave_summary()."""
+
+    def _make_executor(self, task_ids: list[str]) -> WaveExecutor:
+        tasks = [make_task(tid) for tid in task_ids]
+        return WaveExecutor(tasks, task_runner=ok_runner)
+
+    def test_summary_prints_after_each_wave(self, capsys):
+        """print_wave_summary produces visible output."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=False, message="ok:A")}
+        executor.print_wave_summary(results, wave_number=1)
+        captured = capsys.readouterr()
+        assert "Wave 1" in captured.out
+
+    def test_summary_shows_wave_number(self, capsys):
+        executor = self._make_executor(["X"])
+        results = {"X": TaskResult(fatal=False)}
+        executor.print_wave_summary(results, wave_number=3)
+        assert "Wave 3" in capsys.readouterr().out
+
+    def test_summary_shows_succeeded_count(self, capsys):
+        executor = self._make_executor(["A", "B"])
+        results = {
+            "A": TaskResult(fatal=False),
+            "B": TaskResult(fatal=False),
+        }
+        executor.print_wave_summary(results, wave_number=1)
+        assert "2 succeeded" in capsys.readouterr().out
+
+    def test_summary_shows_failed_count(self, capsys):
+        executor = self._make_executor(["A", "B"])
+        results = {
+            "A": TaskResult(fatal=True, message="boom"),
+            "B": TaskResult(fatal=False),
+        }
+        executor.print_wave_summary(results, wave_number=1)
+        assert "1 failed" in capsys.readouterr().out
+
+    def test_summary_shows_skipped_count(self, capsys):
+        executor = self._make_executor(["A", "B"])
+        results = {
+            "A": TaskResult(fatal=False),
+            "B": TaskResult(fatal=True, message="blocked: dependency failed"),
+        }
+        executor.print_wave_summary(results, wave_number=1, skipped_ids=["B"])
+        out = capsys.readouterr().out
+        assert "1 skipped" in out
+
+    def test_per_task_breakdown_includes_task_id(self, capsys):
+        executor = self._make_executor(["my-task"])
+        results = {"my-task": TaskResult(fatal=False)}
+        executor.print_wave_summary(results, wave_number=1)
+        assert "my-task" in capsys.readouterr().out
+
+    def test_per_task_success_shows_checkmark(self, capsys):
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=False)}
+        executor.print_wave_summary(results, wave_number=1)
+        assert "✓" in capsys.readouterr().out
+
+    def test_per_task_failure_shows_cross(self, capsys):
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="something broke")}
+        executor.print_wave_summary(results, wave_number=1)
+        assert "✗" in capsys.readouterr().out
+
+    def test_per_task_skipped_shows_circle(self, capsys):
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="blocked: dependency failed")}
+        executor.print_wave_summary(results, wave_number=1, skipped_ids=["A"])
+        assert "⊘" in capsys.readouterr().out
+
+    def test_failed_task_shows_error_message(self, capsys):
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="assertion error on line 42")}
+        executor.print_wave_summary(results, wave_number=1)
+        assert "assertion error on line 42" in capsys.readouterr().out
+
+    def test_skipped_task_does_not_show_error_message_as_failure(self, capsys):
+        """Skipped (blocked) tasks appear under ⊘, not under ✗."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="blocked: dependency failed")}
+        executor.print_wave_summary(results, wave_number=1, skipped_ids=["A"])
+        out = capsys.readouterr().out
+        assert "⊘" in out
+        assert "✗" not in out
+
+    def test_summary_uses_green_for_succeeded(self, capsys):
+        """Color-coding: succeeded tasks are styled green."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=False)}
+        with patch("click.style") as mock_style:
+            mock_style.side_effect = lambda text, **kw: text
+            executor.print_wave_summary(results, wave_number=1)
+        green_calls = [c for c in mock_style.call_args_list if c.kwargs.get("fg") == "green"]
+        assert green_calls, "expected at least one green-styled element"
+
+    def test_summary_uses_red_for_failed(self, capsys):
+        """Color-coding: failed tasks are styled red."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="boom")}
+        with patch("click.style") as mock_style:
+            mock_style.side_effect = lambda text, **kw: text
+            executor.print_wave_summary(results, wave_number=1)
+        red_calls = [c for c in mock_style.call_args_list if c.kwargs.get("fg") == "red"]
+        assert red_calls, "expected at least one red-styled element"
+
+    def test_summary_uses_yellow_for_skipped(self, capsys):
+        """Color-coding: skipped tasks are styled yellow."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=True, message="blocked: dependency failed")}
+        with patch("click.style") as mock_style:
+            mock_style.side_effect = lambda text, **kw: text
+            executor.print_wave_summary(results, wave_number=1, skipped_ids=["A"])
+        yellow_calls = [c for c in mock_style.call_args_list if c.kwargs.get("fg") == "yellow"]
+        assert yellow_calls, "expected at least one yellow-styled element"
+
+    def test_no_skipped_ids_defaults_to_empty(self, capsys):
+        """Calling without skipped_ids doesn't crash and counts 0 skipped."""
+        executor = self._make_executor(["A"])
+        results = {"A": TaskResult(fatal=False)}
+        executor.print_wave_summary(results, wave_number=1)  # no skipped_ids
+        assert "0 skipped" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# ExecutionReport.wave_histories — populated by run_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestWaveHistories:
+    def test_wave_histories_populated_after_run(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert len(report.wave_histories) == 2
+
+    def test_wave_histories_count_matches_waves_run(self):
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C", ["B"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert len(report.wave_histories) == report.waves_run
+
+    def test_wave_histories_are_wave_summary_instances(self):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert all(isinstance(ws, WaveSummary) for ws in report.wave_histories)
+
+    def test_wave_summary_wave_number_sequential(self):
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        numbers = [ws.wave_number for ws in report.wave_histories]
+        assert numbers == [1, 2]
+
+    def test_wave_summary_succeeded_count_all_ok(self):
+        tasks = [make_task("A"), make_task("B")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert report.wave_histories[0].succeeded == 2
+        assert report.wave_histories[0].failed == 0
+        assert report.wave_histories[0].skipped == 0
+
+    def test_wave_summary_failed_count(self):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        report = executor.run_parallel(tasks)
+        assert report.wave_histories[0].failed == 1
+        assert report.wave_histories[0].succeeded == 0
+
+    def test_wave_summary_skipped_count_blocked_deps(self):
+        """A fails → B (depends on A) is skipped in wave 2."""
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=fail_runner)
+        report = executor.run_parallel(tasks)
+        wave2 = report.wave_histories[1]
+        assert wave2.skipped == 1
+        assert wave2.failed == 0
+
+    def test_wave_summary_total_matches_tasks_in_wave(self):
+        tasks = [make_task("A"), make_task("B"), make_task("C", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        wave1 = report.wave_histories[0]
+        assert wave1.total == 2  # A and B in first wave
+
+    def test_wave_summary_results_contains_task_results(self):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        report = executor.run_parallel(tasks)
+        assert "A" in report.wave_histories[0].results
+        assert isinstance(report.wave_histories[0].results["A"], TaskResult)
+
+    def test_wave_histories_empty_list_on_no_tasks(self):
+        executor = WaveExecutor([])
+        report = executor.run_parallel([])
+        assert report.wave_histories == []
+
+    def test_wave_summary_captures_error_message(self):
+        """Failed task's error message is accessible in wave_histories."""
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=selective_fail_runner({"A"}))
+        report = executor.run_parallel(tasks)
+        result = report.wave_histories[0].results["A"]
+        assert result.fatal
+        assert "error in A" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Integration: summary prints after each wave during run_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestWaveSummaryIntegration:
+    def test_summary_printed_for_each_wave(self, capsys):
+        """run_parallel prints a summary after every wave."""
+        tasks = [make_task("A"), make_task("B", ["A"]), make_task("C", ["B"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        executor.run_parallel(tasks)
+        out = capsys.readouterr().out
+        assert "Wave 1" in out
+        assert "Wave 2" in out
+        assert "Wave 3" in out
+
+    def test_summary_printed_before_next_wave_starts(self, capsys):
+        """Wave N summary appears before Wave N+1 output."""
+        tasks = [make_task("A"), make_task("B", ["A"])]
+        executor = WaveExecutor(tasks, task_runner=ok_runner)
+        executor.run_parallel(tasks)
+        out = capsys.readouterr().out
+        assert out.index("Wave 1") < out.index("Wave 2")
+
+    def test_failed_task_error_visible_in_run_parallel_output(self, capsys):
+        tasks = [make_task("A")]
+        executor = WaveExecutor(tasks, task_runner=selective_fail_runner({"A"}))
+        executor.run_parallel(tasks)
+        assert "error in A" in capsys.readouterr().out


### PR DESCRIPTION
## [M5-06] wave_execution_summary

**Epic:** M5
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Implement post-wave execution reporting in `ralph.py` that displays which tasks succeeded or failed after each wave completes, before starting the next wave. Extend the `WaveExecutor` class from M5-02 with a `print_wave_summary(wave_results: dict[str, TaskResult], wave_number: int) -> None` method. The summary should output: wave number, total tasks in wave, succeeded count (green), failed count (red), skipped count (blocked by previous failures), and a per-task breakdown showing task ID, status (✓/✗/⊘), duration, and brief error message for failures. Use Click's `echo()` with colors via `click.style()` or `click.secho()`. The summary prints immediately after a wave finishes, before WaveExecutor proceeds to build and execute the next wave. This gives operators real-time visibility into batch task progress and helps identify which tasks need attention without waiting for the entire backlog to complete. Store wave results in `ExecutionReport.wave_histories: list[WaveSummary]` for potential post-run analysis.

### Acceptance Criteria
['tests/test_wave_summary.py: wave summary prints after each wave completes', 'tests/test_wave_summary.py: summary shows correct counts for succeeded/failed/skipped', 'tests/test_wave_summary.py: per-task breakdown includes task ID and status', 'tests/test_wave_summary.py: failed tasks show error message in summary', 'tests/test_wave_summary.py: summary uses color coding (green/red/yellow)', 'tests/test_wave_summary.py: ExecutionReport.wave_histories contains all wave summaries']

---
*Ralph Loop — multi-agent AI pair programming*