### PR TITLE
fix: PlanChecker incorrectly rejected valid depends_on as structural error

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -1952,7 +1952,7 @@ class PlanChecker:
         self.validator = validator or PrdValidator()
 
     def check_structural(self, prd: dict) -> list[str]:
-        """Validates required fields, non-empty ACs, and resolved dependencies."""
+        """Validates required fields, non-empty ACs, and that depends_on IDs exist."""
         errors = []
         required_fields = {
             "id",
@@ -1964,7 +1964,6 @@ class PlanChecker:
         }  # noqa: E501
         tasks = prd.get("tasks", [])
         all_ids = {t["id"] for t in tasks}
-        completed_ids = {t["id"] for t in tasks if t.get("completed")}
 
         for task in tasks:
             if task.get("completed"):
@@ -1983,8 +1982,6 @@ class PlanChecker:
             for dep in task.get("depends_on", []):
                 if dep not in all_ids:
                     errors.append(f"{task_id}: depends_on unknown task '{dep}'")
-                elif dep not in completed_ids:
-                    errors.append(f"{task_id}: depends_on incomplete task '{dep}'")
 
             try:
                 self.validator.validate(task, all_ids)


### PR DESCRIPTION
## Summary
- `check_structural()` was treating any `depends_on` referencing an *incomplete* task as a structural error
- This blocked sprint start whenever tasks had `depends_on` relationships (the normal M6 state: M6-02..05 all depend on M6-01)
- Only unknown task IDs are a real structural error; runtime ordering is already handled by `TaskTracker._get_next_task()`

## Fix
Remove the `elif dep not in completed_ids` check and the now-unused `completed_ids` variable from `check_structural`.

## Test plan
- [ ] All 516 existing tests pass (pre-commit confirmed)
- [ ] `uv run rzilla run --task M6-01` no longer fails preflight with "depends_on incomplete task" errors