### PR TITLE
Add --project-dir arg to MCP server for cross-project usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ Add to `~/.config/opencode/opencode.json` (global) or your project's local confi
   "mcp": {
     "rzilla": {
       "type": "local",
-      "command": ["/abs/path/to/ralphzilla/.venv/bin/python", "/abs/path/to/ralphzilla/ralph_mcp.py", "--project-dir", "/abs/path/to/your/project"],
+      "command": ["/abs/path/to/ralphzilla/.venv/bin/python", "/abs/path/to/ralphzilla/ralph_mcp.py", "--repo-dir", "/abs/path/to/your/project"],
       "enabled": true
     }
   }
 }
 ```
 
-> **Important**: Use the absolute path to the venv Python binary, **not** `uv run --extra mcp`. The `uv run` command resolves extras from the current project's `pyproject.toml`, so it fails when opencode starts from a different directory.
+> **Important**: Use the absolute path to the venv Python binary, **not** `uv run --extra mcp`. The `uv run` command resolves extras from the current project's `pyproject.toml`, so it fails when opencode starts from a different directory. Keep `cwd` pointed at the ralphzilla checkout — `--repo-dir` tells rzilla which repo to operate on, but subprocesses still run from the ralphzilla environment.
 
 ### Setup for other MCP clients
 
@@ -131,14 +131,14 @@ Create a `.mcp.json` in your project root:
   "mcpServers": {
     "rzilla": {
       "command": "/abs/path/to/ralphzilla/.venv/bin/python",
-      "args": ["/abs/path/to/ralphzilla/ralph_mcp.py", "--project-dir", "/abs/path/to/your/project"],
+      "args": ["/abs/path/to/ralphzilla/ralph_mcp.py", "--repo-dir", "/abs/path/to/your/project"],
       "cwd": "/abs/path/to/ralphzilla"
     }
   }
 }
 ```
 
-The `--project-dir` argument tells the MCP server which project's `prd.json` to read. Without it, the server defaults to ralphzilla's own `prd.json`.
+The `--repo-dir` argument tells the MCP server which project's `prd.json` to read (matching the `rzilla run --repo-dir` CLI flag). Without it, the server defaults to ralphzilla's own `prd.json`. Keep `cwd` set to the ralphzilla checkout so `uv run rzilla` resolves correctly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Add to `~/.config/opencode/opencode.json` (global) or your project's local confi
   "mcp": {
     "rzilla": {
       "type": "local",
-      "command": ["/abs/path/to/ralphzilla/.venv/bin/python", "/abs/path/to/ralphzilla/ralph_mcp.py"],
+      "command": ["/abs/path/to/ralphzilla/.venv/bin/python", "/abs/path/to/ralphzilla/ralph_mcp.py", "--project-dir", "/abs/path/to/your/project"],
       "enabled": true
     }
   }
@@ -131,12 +131,14 @@ Create a `.mcp.json` in your project root:
   "mcpServers": {
     "rzilla": {
       "command": "/abs/path/to/ralphzilla/.venv/bin/python",
-      "args": ["/abs/path/to/ralphzilla/ralph_mcp.py"],
+      "args": ["/abs/path/to/ralphzilla/ralph_mcp.py", "--project-dir", "/abs/path/to/your/project"],
       "cwd": "/abs/path/to/ralphzilla"
     }
   }
 }
 ```
+
+The `--project-dir` argument tells the MCP server which project's `prd.json` to read. Without it, the server defaults to ralphzilla's own `prd.json`.
 
 ---
 

--- a/ralph_mcp.py
+++ b/ralph_mcp.py
@@ -18,7 +18,7 @@ Usage:
     # For MCP client config (.mcp.json / opencode.json), use absolute venv path:
     # /path/to/ralphzilla/.venv/bin/python /path/to/ralphzilla/ralph_mcp.py
     # To target a different project's prd.json:
-    #   ralph_mcp.py --project-dir /path/to/project
+    #   ralph_mcp.py --repo-dir /path/to/project
 """
 
 from __future__ import annotations
@@ -38,17 +38,25 @@ from mcp.server.fastmcp import FastMCP
 
 REPO_DIR = Path(__file__).parent
 
-_project_dir_arg = REPO_DIR
+_repo_dir_arg = REPO_DIR
 for i, arg in enumerate(sys.argv[1:], 1):
-    if arg == "--project-dir" and i < len(sys.argv) - 1:
-        _project_dir_arg = Path(sys.argv[i + 1]).resolve()
+    if arg == "--repo-dir":
+        if i >= len(sys.argv) - 1:
+            print("Error: --repo-dir requires a path argument", file=sys.stderr)
+            sys.exit(1)
+        _repo_dir_arg = Path(sys.argv[i + 1]).expanduser().resolve()
+        if not _repo_dir_arg.is_dir():
+            print(f"Error: --repo-dir {_repo_dir_arg} is not a directory", file=sys.stderr)
+            sys.exit(1)
         sys.argv[i : i + 2] = []
         break
 
-PROJECT_DIR = _project_dir_arg
+PROJECT_DIR = _repo_dir_arg
 PRD_FILE = PROJECT_DIR / "prd.json"
 PROGRESS_FILE = PROJECT_DIR / "progress.txt"
 LOG_FILE = PROJECT_DIR / "ralph-loop.log"
+
+_repo_dir_flag = ["--repo-dir", str(PROJECT_DIR)] if PROJECT_DIR != REPO_DIR else []
 
 mcp = FastMCP("rzilla")
 
@@ -253,7 +261,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
     Returns:
         stdout+stderr from the dry-run command
     """
-    cmd = ["uv", "run", "rzilla", "run", "--dry-run"]
+    cmd = ["uv", "run", "rzilla", "run", "--dry-run"] + _repo_dir_flag
     if task:
         cmd.extend(["--task", task])
 
@@ -262,7 +270,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(PROJECT_DIR),
+            cwd=str(REPO_DIR),
             timeout=30,
         )
         output = result.stdout
@@ -299,7 +307,7 @@ def rzilla_run(
     Returns:
         JSON string with pid, message, and log_file path
     """
-    cmd = ["uv", "run", "rzilla", "run"]
+    cmd = ["uv", "run", "rzilla", "run"] + _repo_dir_flag
 
     if task:
         cmd.extend(["--task", task])
@@ -322,7 +330,7 @@ def rzilla_run(
                 cmd,
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
-                cwd=str(PROJECT_DIR),
+                cwd=str(REPO_DIR),
                 start_new_session=True,
             )
 
@@ -362,14 +370,14 @@ def rzilla_add(spec: str) -> str:
     Returns:
         Output from the rzilla add command
     """
-    cmd = ["uv", "run", "rzilla", "add", spec]
+    cmd = ["uv", "run", "rzilla", "add", spec] + _repo_dir_flag
 
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(PROJECT_DIR),
+            cwd=str(REPO_DIR),
             timeout=60,
         )
         output = result.stdout

--- a/ralph_mcp.py
+++ b/ralph_mcp.py
@@ -38,26 +38,46 @@ from mcp.server.fastmcp import FastMCP
 
 REPO_DIR = Path(__file__).parent
 
-_repo_dir_arg = REPO_DIR
-for i, arg in enumerate(sys.argv[1:], 1):
-    if arg == "--repo-dir":
-        if i >= len(sys.argv) - 1:
-            print("Error: --repo-dir requires a path argument", file=sys.stderr)
-            sys.exit(1)
-        _repo_dir_arg = Path(sys.argv[i + 1]).expanduser().resolve()
-        if not _repo_dir_arg.is_dir():
-            print(f"Error: --repo-dir {_repo_dir_arg} is not a directory", file=sys.stderr)
-            sys.exit(1)
-        sys.argv[i : i + 2] = []
-        break
 
-PROJECT_DIR = _repo_dir_arg
-PRD_FILE = PROJECT_DIR / "prd.json"
-PROGRESS_FILE = PROJECT_DIR / "progress.txt"
-LOG_FILE = PROJECT_DIR / "ralph-loop.log"
+def _set_project_dir(project_dir: Path) -> None:
+    global PROJECT_DIR, PRD_FILE, PROGRESS_FILE, LOG_FILE, _repo_dir_flag
 
-_repo_dir_flag = ["--repo-dir", str(PROJECT_DIR)] if PROJECT_DIR != REPO_DIR else []
+    PROJECT_DIR = project_dir
+    PRD_FILE = PROJECT_DIR / "prd.json"
+    PROGRESS_FILE = PROJECT_DIR / "progress.txt"
+    LOG_FILE = PROJECT_DIR / "ralph-loop.log"
+    _repo_dir_flag = ["--repo-dir", str(PROJECT_DIR)] if PROJECT_DIR != REPO_DIR else []
 
+
+def _parse_repo_dir_args(argv: list[str]) -> tuple[Path, list[str]]:
+    project_dir = REPO_DIR
+    cleaned_argv = [argv[0]]
+    i = 1
+
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--repo-dir":
+            if i + 1 >= len(argv):
+                print("Error: --repo-dir requires a path argument", file=sys.stderr)
+                sys.exit(1)
+            project_dir = Path(argv[i + 1]).expanduser().resolve()
+            if not project_dir.is_dir():
+                print(f"Error: --repo-dir {project_dir} is not a directory", file=sys.stderr)
+                sys.exit(1)
+            i += 2
+            continue
+        cleaned_argv.append(arg)
+        i += 1
+
+    return project_dir, cleaned_argv
+
+
+_set_project_dir(REPO_DIR)
+
+if __name__ == "__main__":
+    _project_dir_arg, _cleaned_argv = _parse_repo_dir_args(sys.argv)
+    _set_project_dir(_project_dir_arg)
+    sys.argv[:] = _cleaned_argv
 mcp = FastMCP("rzilla")
 
 

--- a/ralph_mcp.py
+++ b/ralph_mcp.py
@@ -17,6 +17,8 @@ Usage:
     uv run --extra mcp python ralph_mcp.py
     # For MCP client config (.mcp.json / opencode.json), use absolute venv path:
     # /path/to/ralphzilla/.venv/bin/python /path/to/ralphzilla/ralph_mcp.py
+    # To target a different project's prd.json:
+    #   ralph_mcp.py --project-dir /path/to/project
 """
 
 from __future__ import annotations
@@ -26,17 +28,27 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 from pathlib import Path
 
-os.environ["MCP_LOG_LEVEL"] = "ERROR"
+os.environ.setdefault("MCP_LOG_LEVEL", "ERROR")
 
 import psutil
 from mcp.server.fastmcp import FastMCP
 
 REPO_DIR = Path(__file__).parent
-PRD_FILE = REPO_DIR / "prd.json"
-PROGRESS_FILE = REPO_DIR / "progress.txt"
-LOG_FILE = REPO_DIR / "ralph-loop.log"
+
+_project_dir_arg = REPO_DIR
+for i, arg in enumerate(sys.argv[1:], 1):
+    if arg == "--project-dir" and i < len(sys.argv) - 1:
+        _project_dir_arg = Path(sys.argv[i + 1]).resolve()
+        sys.argv[i : i + 2] = []
+        break
+
+PROJECT_DIR = _project_dir_arg
+PRD_FILE = PROJECT_DIR / "prd.json"
+PROGRESS_FILE = PROJECT_DIR / "progress.txt"
+LOG_FILE = PROJECT_DIR / "ralph-loop.log"
 
 mcp = FastMCP("rzilla")
 
@@ -62,6 +74,7 @@ _configure_mcp_logging()
 
 # --- Helper Functions ---
 
+
 def _read_prd() -> dict:
     """Read and parse prd.json from disk."""
     if not PRD_FILE.exists():
@@ -72,7 +85,7 @@ def _read_prd() -> dict:
 
 def _find_latest_summary() -> Path | None:
     """Find the most recent ralph-summary-*.md file."""
-    summaries = sorted(REPO_DIR.glob("ralph-summary-*.md"))
+    summaries = sorted(PROJECT_DIR.glob("ralph-summary-*.md"))
     return summaries[-1] if summaries else None
 
 
@@ -101,6 +114,7 @@ def _get_rzilla_pid() -> int | None:
 
 
 # --- MCP Tools ---
+
 
 @mcp.tool(annotations={"readOnlyHint": True})
 def rzilla_status() -> str:
@@ -248,7 +262,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(REPO_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=30,
         )
         output = result.stdout
@@ -308,7 +322,7 @@ def rzilla_run(
                 cmd,
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
-                cwd=str(REPO_DIR),
+                cwd=str(PROJECT_DIR),
                 start_new_session=True,
             )
 
@@ -355,7 +369,7 @@ def rzilla_add(spec: str) -> str:
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(REPO_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=60,
         )
         output = result.stdout

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -591,9 +591,6 @@ class TestMCPLoggingConfig:
 
     def test_server_produces_no_stderr_on_startup(self):
         """Server must emit nothing to stderr when launched with empty stdin."""
-        import subprocess
-        import sys
-
         result = subprocess.run(
             [sys.executable, "-m", "ralph_mcp"],
             stdin=subprocess.DEVNULL,
@@ -614,20 +611,16 @@ class TestRepoDirArg:
 
     def test_prd_file_derived_from_project_dir(self, tmp_path):
         """PRD_FILE, PROGRESS_FILE, LOG_FILE derive from PROJECT_DIR."""
-        import importlib
-
-        original_argv = sys.argv[:]
+        original_project_dir = mcp_module.PROJECT_DIR
         try:
-            sys.argv = [original_argv[0], "--repo-dir", str(tmp_path)]
-            importlib.reload(mcp_module)
+            mcp_module._set_project_dir(tmp_path)
 
             assert mcp_module.PROJECT_DIR == tmp_path
             assert mcp_module.PRD_FILE == tmp_path / "prd.json"
             assert mcp_module.PROGRESS_FILE == tmp_path / "progress.txt"
             assert mcp_module.LOG_FILE == tmp_path / "ralph-loop.log"
         finally:
-            sys.argv = original_argv
-            importlib.reload(mcp_module)
+            mcp_module._set_project_dir(original_project_dir)
 
     def test_read_prd_from_project_dir(self, tmp_path):
         """_read_prd reads from PROJECT_DIR, not REPO_DIR."""
@@ -650,9 +643,6 @@ class TestRepoDirArg:
 
     def test_repo_dir_cli_arg(self, tmp_path):
         """Server accepts --repo-dir and resolves paths accordingly."""
-        import subprocess
-        import sys
-
         prd_data = {"tasks": [{"id": "P-01", "title": "Project task"}]}
         prd_file = tmp_path / "prd.json"
         prd_file.write_text(json.dumps(prd_data))
@@ -687,9 +677,6 @@ class TestRepoDirArg:
 
     def test_repo_dir_missing_value_exits(self):
         """--repo-dir without a value prints error and exits."""
-        import subprocess
-        import sys
-
         result = subprocess.run(
             [sys.executable, str(mcp_module.REPO_DIR / "ralph_mcp.py"), "--repo-dir"],
             capture_output=True,
@@ -701,9 +688,6 @@ class TestRepoDirArg:
 
     def test_repo_dir_invalid_path_exits(self):
         """--repo-dir with non-existent path prints error and exits."""
-        import subprocess
-        import sys
-
         result = subprocess.run(
             [
                 sys.executable,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -39,7 +39,7 @@ class TestFindLatestSummary:
 
     def test_returns_none_when_no_summaries(self, tmp_path):
         """When no ralph-summary-*.md files exist, return None."""
-        with patch.object(mcp_module, "REPO_DIR", tmp_path):
+        with patch.object(mcp_module, "PROJECT_DIR", tmp_path):
             result = mcp_module._find_latest_summary()
             assert result is None
 
@@ -54,7 +54,7 @@ class TestFindLatestSummary:
         summary2.write_text("Newest summary")
         summary3.write_text("Middle summary")
 
-        with patch.object(mcp_module, "REPO_DIR", tmp_path):
+        with patch.object(mcp_module, "PROJECT_DIR", tmp_path):
             result = mcp_module._find_latest_summary()
             assert result == summary2
 
@@ -257,7 +257,7 @@ class TestRzillaSummary:
 
     def test_returns_no_summary_when_none_exists(self, tmp_path):
         """When no summary files exist, return appropriate message."""
-        with patch.object(mcp_module, "REPO_DIR", tmp_path):
+        with patch.object(mcp_module, "PROJECT_DIR", tmp_path):
             result = mcp_module.rzilla_summary()
             assert result == "No sprint summary found."
 
@@ -269,7 +269,7 @@ class TestRzillaSummary:
         summary1.write_text("# Old Summary")
         summary2.write_text("# Latest Sprint Summary\n\nCompleted 5 tasks.")
 
-        with patch.object(mcp_module, "REPO_DIR", tmp_path):
+        with patch.object(mcp_module, "PROJECT_DIR", tmp_path):
             result = mcp_module.rzilla_summary()
             assert result == "# Latest Sprint Summary\n\nCompleted 5 tasks."
 
@@ -602,3 +602,79 @@ class TestMCPLoggingConfig:
             cwd=str(mcp_module.REPO_DIR),
         )
         assert result.stderr == "", f"Unexpected stderr output: {result.stderr[:200]}"
+
+
+class TestProjectDirArg:
+    """Tests for --project-dir CLI argument."""
+
+    def test_default_project_dir_is_repo_dir(self):
+        """Without --project-dir, PROJECT_DIR equals REPO_DIR."""
+        assert mcp_module.PROJECT_DIR == mcp_module.REPO_DIR
+
+    def test_prd_file_uses_project_dir(self, tmp_path):
+        """PRD_FILE, PROGRESS_FILE, LOG_FILE resolve under PROJECT_DIR."""
+        with (
+            patch.object(mcp_module, "PROJECT_DIR", tmp_path),
+            patch.object(mcp_module, "PRD_FILE", tmp_path / "prd.json"),
+            patch.object(mcp_module, "PROGRESS_FILE", tmp_path / "progress.txt"),
+            patch.object(mcp_module, "LOG_FILE", tmp_path / "ralph-loop.log"),
+        ):
+            assert mcp_module.PRD_FILE == tmp_path / "prd.json"
+            assert mcp_module.PROGRESS_FILE == tmp_path / "progress.txt"
+            assert mcp_module.LOG_FILE == tmp_path / "ralph-loop.log"
+
+    def test_read_prd_from_project_dir(self, tmp_path):
+        """_read_prd reads from PROJECT_DIR, not REPO_DIR."""
+        prd_data = {"tasks": [{"id": "EXT-01", "title": "External task"}]}
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text(json.dumps(prd_data))
+
+        with patch.object(mcp_module, "PRD_FILE", prd_file):
+            result = mcp_module._read_prd()
+        assert result == prd_data
+
+    def test_find_latest_summary_in_project_dir(self, tmp_path):
+        """_find_latest_summary searches PROJECT_DIR, not REPO_DIR."""
+        summary = tmp_path / "ralph-summary-2024-06-01.md"
+        summary.write_text("# Sprint summary")
+
+        with patch.object(mcp_module, "PROJECT_DIR", tmp_path):
+            result = mcp_module._find_latest_summary()
+        assert result == summary
+
+    def test_project_dir_cli_arg(self, tmp_path):
+        """Server accepts --project-dir and resolves paths accordingly."""
+        import subprocess
+        import sys
+
+        prd_data = {"tasks": [{"id": "P-01", "title": "Project task"}]}
+        prd_file = tmp_path / "prd.json"
+        prd_file.write_text(json.dumps(prd_data))
+
+        init_msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(mcp_module.REPO_DIR / "ralph_mcp.py"),
+                "--project-dir",
+                str(tmp_path),
+            ],
+            input=init_msg,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.stderr == "", f"Unexpected stderr: {result.stderr[:200]}"
+        assert "rzilla" in result.stdout

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,6 +8,7 @@ the 8 MCP tools work correctly without touching real infrastructure.
 import json
 import signal
 import subprocess
+import sys
 from unittest.mock import MagicMock, Mock, patch
 
 # Import the module under test
@@ -604,24 +605,29 @@ class TestMCPLoggingConfig:
         assert result.stderr == "", f"Unexpected stderr output: {result.stderr[:200]}"
 
 
-class TestProjectDirArg:
-    """Tests for --project-dir CLI argument."""
+class TestRepoDirArg:
+    """Tests for --repo-dir CLI argument."""
 
     def test_default_project_dir_is_repo_dir(self):
-        """Without --project-dir, PROJECT_DIR equals REPO_DIR."""
+        """Without --repo-dir, PROJECT_DIR equals REPO_DIR."""
         assert mcp_module.PROJECT_DIR == mcp_module.REPO_DIR
 
-    def test_prd_file_uses_project_dir(self, tmp_path):
-        """PRD_FILE, PROGRESS_FILE, LOG_FILE resolve under PROJECT_DIR."""
-        with (
-            patch.object(mcp_module, "PROJECT_DIR", tmp_path),
-            patch.object(mcp_module, "PRD_FILE", tmp_path / "prd.json"),
-            patch.object(mcp_module, "PROGRESS_FILE", tmp_path / "progress.txt"),
-            patch.object(mcp_module, "LOG_FILE", tmp_path / "ralph-loop.log"),
-        ):
+    def test_prd_file_derived_from_project_dir(self, tmp_path):
+        """PRD_FILE, PROGRESS_FILE, LOG_FILE derive from PROJECT_DIR."""
+        import importlib
+
+        original_argv = sys.argv[:]
+        try:
+            sys.argv = [original_argv[0], "--repo-dir", str(tmp_path)]
+            importlib.reload(mcp_module)
+
+            assert mcp_module.PROJECT_DIR == tmp_path
             assert mcp_module.PRD_FILE == tmp_path / "prd.json"
             assert mcp_module.PROGRESS_FILE == tmp_path / "progress.txt"
             assert mcp_module.LOG_FILE == tmp_path / "ralph-loop.log"
+        finally:
+            sys.argv = original_argv
+            importlib.reload(mcp_module)
 
     def test_read_prd_from_project_dir(self, tmp_path):
         """_read_prd reads from PROJECT_DIR, not REPO_DIR."""
@@ -642,8 +648,8 @@ class TestProjectDirArg:
             result = mcp_module._find_latest_summary()
         assert result == summary
 
-    def test_project_dir_cli_arg(self, tmp_path):
-        """Server accepts --project-dir and resolves paths accordingly."""
+    def test_repo_dir_cli_arg(self, tmp_path):
+        """Server accepts --repo-dir and resolves paths accordingly."""
         import subprocess
         import sys
 
@@ -668,7 +674,7 @@ class TestProjectDirArg:
             [
                 sys.executable,
                 str(mcp_module.REPO_DIR / "ralph_mcp.py"),
-                "--project-dir",
+                "--repo-dir",
                 str(tmp_path),
             ],
             input=init_msg,
@@ -678,3 +684,36 @@ class TestProjectDirArg:
         )
         assert result.stderr == "", f"Unexpected stderr: {result.stderr[:200]}"
         assert "rzilla" in result.stdout
+
+    def test_repo_dir_missing_value_exits(self):
+        """--repo-dir without a value prints error and exits."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, str(mcp_module.REPO_DIR / "ralph_mcp.py"), "--repo-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode != 0
+        assert "--repo-dir" in result.stderr
+
+    def test_repo_dir_invalid_path_exits(self):
+        """--repo-dir with non-existent path prints error and exits."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(mcp_module.REPO_DIR / "ralph_mcp.py"),
+                "--repo-dir",
+                "/nonexistent/path/xyz",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode != 0
+        assert "not a directory" in result.stderr


### PR DESCRIPTION
## Summary

Fixes #55 — MCP server reads ralphzilla's own `prd.json` instead of the host project's.

## Problem

The MCP server hardcoded `REPO_DIR = Path(__file__).parent` for all file paths (`prd.json`, `progress.txt`, `ralph-summary-*.md`, subprocess `cwd`). This meant that when the MCP server was configured in another project's `.mcp.json` (e.g., piewise), all tools like `rzilla_tasks` and `rzilla_status` would report ralphzilla's 60 tasks instead of the project's own backlog.

## Changes

### `ralph_mcp.py`

- **Add `--project-dir` CLI argument**: Parse `sys.argv` before FastMCP loads to extract `--project-dir <path>`. Strip it from `sys.argv` so FastMCP doesn't choke on unknown args.
- **Introduce `PROJECT_DIR` constant**: Defaults to `REPO_DIR` (ralphzilla) but overridden when `--project-dir` is provided.
- **Route file paths through `PROJECT_DIR`**: `PRD_FILE`, `PROGRESS_FILE`, `LOG_FILE` all resolve under `PROJECT_DIR`. `_find_latest_summary()` searches `PROJECT_DIR`. Subprocess `cwd` uses `PROJECT_DIR`.
- **`REPO_DIR` preserved**: Still available as ralphzilla's install directory (may be needed for finding the `rzilla` CLI).

### `tests/test_mcp_server.py`

- Update existing tests that patched `REPO_DIR` → `PROJECT_DIR` (4 tests in `TestFindLatestSummary` and `TestRzillaSummary`).
- Add `TestProjectDirArg` class with 5 new tests:
  - Default `PROJECT_DIR == REPO_DIR`
  - File paths resolve under `PROJECT_DIR`
  - `_read_prd` reads from project dir
  - `_find_latest_summary` searches project dir
  - Server accepts `--project-dir` via CLI and initializes correctly

### `README.md`

- Update opencode and `.mcp.json` config examples to include `--project-dir` arg.
- Add explanation that `--project-dir` determines which project's `prd.json` is read.

## Usage

```json
{
  "mcpServers": {
    "rzilla": {
      "command": "/path/to/ralphzilla/.venv/bin/python",
      "args": ["/path/to/ralphzilla/ralph_mcp.py", "--project-dir", "/path/to/your/project"]
    }
  }
}
```

Without `--project-dir`, the server defaults to ralphzilla's own `prd.json` (backward compatible).

## Testing

- 41/41 MCP tests pass
- 558/558 total tests pass
- Ruff lint and format clean

Fixes #55