### PR TITLE
fix: per-project MCP config — auto-detect repo root from cwd

### DIFF
--- a/ralph_mcp.py
+++ b/ralph_mcp.py
@@ -13,7 +13,7 @@ Exposes 8 MCP tools for monitoring and controlling the ralphzilla sprint loop:
 - rzilla_abort: Abort running sprint
 
 Usage:
-    # Run from the ralphzilla checkout (so uv can find ralphzilla's pyproject.toml):
+    # From any repo (auto-detects git root from cwd):
     uv run --extra mcp python ralph_mcp.py
     # For MCP client config (.mcp.json / opencode.json), use absolute venv path:
     # /path/to/ralphzilla/.venv/bin/python /path/to/ralphzilla/ralph_mcp.py
@@ -23,9 +23,6 @@ Usage:
 By default, the server resolves the project directory by walking up from cwd
 to find the nearest .git directory. This means each project's .mcp.json does
 not need to specify --repo-dir — just set cwd to the project root.
-Note: the uv subprocess (rzilla CLI) is always invoked from the ralphzilla
-checkout directory so that uv resolves its scripts correctly; --repo-dir is
-passed on every command to target the project's prd.json.
 """
 
 from __future__ import annotations
@@ -308,7 +305,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
     Returns:
         stdout+stderr from the dry-run command
     """
-    cmd = ["uv", "run", "rzilla", "run", "--dry-run"] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "run", "--dry-run"] + _repo_dir_flag
     if task:
         cmd.extend(["--task", task])
 
@@ -317,7 +314,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(RALPH_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=30,
         )
         output = result.stdout
@@ -358,7 +355,7 @@ def rzilla_run(
     Returns:
         JSON string with pid, message, and log_file path
     """
-    cmd = ["uv", "run", "rzilla", "run"] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "run"] + _repo_dir_flag
 
     if task:
         cmd.extend(["--task", task])
@@ -386,7 +383,7 @@ def rzilla_run(
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                cwd=str(RALPH_DIR),
+                cwd=str(PROJECT_DIR),
                 start_new_session=True,
             )
 
@@ -426,14 +423,14 @@ def rzilla_add(spec: str) -> str:
     Returns:
         Output from the rzilla add command
     """
-    cmd = ["uv", "run", "rzilla", "add", spec] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "add", spec] + _repo_dir_flag
 
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(RALPH_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=60,
         )
         output = result.stdout

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -289,7 +289,7 @@ class TestRzillaDryRun:
 
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args[0] == "uv"
+        assert call_args[0].endswith("rzilla")
         assert "--dry-run" in call_args
         assert "--task" not in call_args
         assert result == "Dry run output"
@@ -391,11 +391,9 @@ class TestRzillaAdd:
 
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args[0] == "uv"
-        assert call_args[1] == "run"
-        assert call_args[2] == "rzilla"
-        assert call_args[3] == "add"
-        assert call_args[4] == "Implement feature X"
+        assert call_args[0].endswith("rzilla")
+        assert "add" in call_args
+        assert "Implement feature X" in call_args
         assert result == "Added task: TASK-99 - Implement feature X"
 
     def test_handles_timeout(self):


### PR DESCRIPTION
## Summary
- The global rzilla MCP config in `opencode.json` pinned the server to a single project's `prd.json`, causing confusion when working across multiple repos (ralphzilla vs PieWise)
- Added `_find_repo_root()` to `ralph_mcp.py` that walks up from cwd to find the nearest `.git` directory, so each project's `.mcp.json` only needs to set `cwd` — no `--repo-dir` required
- Updated README MCP setup section: removed global config instructions, added clear per-project `.mcp.json` guidance with key points about `cwd`-based detection

## Changes
- `ralph_mcp.py`: auto-detect project from cwd instead of hardcoding to ralphzilla repo; fix subprocess `cwd` to use `PROJECT_DIR` instead of `REPO_DIR`; always pass `--repo-dir` for clarity
- `README.md`: replace global + per-project dual setup with single per-project `.mcp.json` pattern; emphasize that global config causes cross-project confusion