### PR TITLE
fix: use direct venv path for rzilla in MCP server

### DIFF
--- a/ralph_mcp.py
+++ b/ralph_mcp.py
@@ -13,7 +13,7 @@ Exposes 8 MCP tools for monitoring and controlling the ralphzilla sprint loop:
 - rzilla_abort: Abort running sprint
 
 Usage:
-    # Run from the ralphzilla checkout (so uv can find ralphzilla's pyproject.toml):
+    # From any repo (auto-detects git root from cwd):
     uv run --extra mcp python ralph_mcp.py
     # For MCP client config (.mcp.json / opencode.json), use absolute venv path:
     # /path/to/ralphzilla/.venv/bin/python /path/to/ralphzilla/ralph_mcp.py
@@ -23,9 +23,6 @@ Usage:
 By default, the server resolves the project directory by walking up from cwd
 to find the nearest .git directory. This means each project's .mcp.json does
 not need to specify --repo-dir — just set cwd to the project root.
-Note: the uv subprocess (rzilla CLI) is always invoked from the ralphzilla
-checkout directory so that uv resolves its scripts correctly; --repo-dir is
-passed on every command to target the project's prd.json.
 """
 
 from __future__ import annotations
@@ -308,7 +305,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
     Returns:
         stdout+stderr from the dry-run command
     """
-    cmd = ["uv", "run", "rzilla", "run", "--dry-run"] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "run", "--dry-run"] + _repo_dir_flag
     if task:
         cmd.extend(["--task", task])
 
@@ -317,7 +314,7 @@ def rzilla_dry_run(task: str | None = None) -> str:
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(RALPH_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=30,
         )
         output = result.stdout
@@ -358,7 +355,7 @@ def rzilla_run(
     Returns:
         JSON string with pid, message, and log_file path
     """
-    cmd = ["uv", "run", "rzilla", "run"] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "run"] + _repo_dir_flag
 
     if task:
         cmd.extend(["--task", task])
@@ -386,7 +383,7 @@ def rzilla_run(
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                cwd=str(RALPH_DIR),
+                cwd=str(PROJECT_DIR),
                 start_new_session=True,
             )
 
@@ -426,14 +423,14 @@ def rzilla_add(spec: str) -> str:
     Returns:
         Output from the rzilla add command
     """
-    cmd = ["uv", "run", "rzilla", "add", spec] + _repo_dir_flag
+    cmd = [str(RALPH_DIR / ".venv" / "bin" / "rzilla"), "add", spec] + _repo_dir_flag
 
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
-            cwd=str(RALPH_DIR),
+            cwd=str(PROJECT_DIR),
             timeout=60,
         )
         output = result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,3 +114,31 @@ class TestCLIFlags:
 
         for field in expected_fields:
             assert field in ralph.Config.__dataclass_fields__, f"Config missing field: {field}"
+
+
+class TestFindRepoRoot:
+    """Tests for _find_repo_root defaulting logic."""
+
+    def test_finds_git_root_from_cwd(self, monkeypatch, tmp_path):
+        """Should find .git dir by walking up from cwd."""
+        git_dir = tmp_path / "project"
+        git_dir.mkdir()
+        (git_dir / ".git").mkdir()
+        sub = git_dir / "src" / "pkg"
+        sub.mkdir(parents=True)
+        monkeypatch.chdir(sub)
+        assert ralph._find_repo_root() == git_dir.resolve()
+
+    def test_falls_back_to_cwd_when_no_git(self, monkeypatch, tmp_path):
+        """Should fall back to cwd when no .git found anywhere above."""
+        no_git = tmp_path / "nogit"
+        no_git.mkdir()
+        monkeypatch.chdir(no_git)
+        assert ralph._find_repo_root() == no_git.resolve()
+
+    def test_finds_repo_root_from_repo_root(self, monkeypatch):
+        """Should find .git when cwd IS the repo root."""
+        monkeypatch.chdir(Path(__file__).parent.parent)
+        result = ralph._find_repo_root()
+        assert (result / ".git").exists()
+        assert result == Path(__file__).parent.parent.resolve()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -289,7 +289,7 @@ class TestRzillaDryRun:
 
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args[0] == "uv"
+        assert call_args[0].endswith("rzilla")
         assert "--dry-run" in call_args
         assert "--task" not in call_args
         assert result == "Dry run output"
@@ -391,11 +391,9 @@ class TestRzillaAdd:
 
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args[0] == "uv"
-        assert call_args[1] == "run"
-        assert call_args[2] == "rzilla"
-        assert call_args[3] == "add"
-        assert call_args[4] == "Implement feature X"
+        assert call_args[0].endswith("rzilla")
+        assert "add" in call_args
+        assert "Implement feature X" in call_args
         assert result == "Added task: TASK-99 - Implement feature X"
 
     def test_handles_timeout(self):


### PR DESCRIPTION
## Summary
- Replaces `uv run rzilla` with direct `.venv/bin/rzilla` path in `rzilla_dry_run`, `rzilla_run`, and `rzilla_add`
- Fixes Copilot review feedback on #60: `uv run` was failing when `cwd=PROJECT_DIR` because uv couldn't find ralphzilla's pyproject.toml in an arbitrary target repo
- Adds 3 tests for `_find_repo_root()` cwd-based project detection

## Test plan
- [ ] CI passes
- [ ] `rzilla_run` works from a non-ralphzilla project directory