### PR TITLE
refactor: make opencode default agent instead of claude

### DIFF
--- a/ralph.py
+++ b/ralph.py
@@ -54,6 +54,7 @@ LOG_FILE_NAME = "ralph.log"
 PRD_FILE = "prd.json"
 PROGRESS_FILE = "progress.txt"
 SUMMARY_FILE_PREFIX = "ralph-summary"
+DEFAULT_AGENT = "opencode"
 DEFAULT_OPENCODE_MODEL = "opencode/big-pickle"
 DEFAULT_OPENCODE_REVIEWER_MODEL = "opencode/kimi-k2.5"
 DEFAULT_OPENCODE_TEST_WRITER_MODEL = "opencode/minimax-m2.7"
@@ -967,7 +968,7 @@ class ReviewQualityChecker:
         if self.config.opencode_only:
             available_agents = ["opencode", "gemini", "claude"]
         else:
-            available_agents = ["gemini", "opencode", "claude"]
+            available_agents = ["opencode", "gemini", "claude"]
         retry_agent = available_agents[(round_num + 1) % len(available_agents)]
         return result, retry_agent
 
@@ -1125,7 +1126,7 @@ class PlanConsensus:
 
             critic_prompt = PromptBuilder.critic_prompt(plan_output)
             self.logger.info("Invoking Critic agent")
-            critic_output = self.ai_runner.run_reviewer("claude", critic_prompt)
+            critic_output = self.ai_runner.run_reviewer(DEFAULT_AGENT, critic_prompt)
 
             verdict, reason = self._parse_critic(critic_output)
 
@@ -4024,7 +4025,7 @@ class AIRunner:
     def run_test_writer(self, prompt: str, cwd: Path, agent: str | None = None) -> bool:
         """Test writer always uses a different model from coder."""
         if agent is None:
-            agent = "gemini" if self._is_nested_claude_session() else "claude"
+            agent = "gemini" if self._is_nested_claude_session() else DEFAULT_AGENT
         if agent == "opencode":
             return self.run_coder(
                 agent,
@@ -4037,7 +4038,7 @@ class AIRunner:
     def run_decompose(self, task: dict) -> list[dict]:
         """AI decompose complexity-3 task."""
         prompt = PromptBuilder.decompose_prompt(task)
-        output = self.run_reviewer("claude", prompt)
+        output = self.run_reviewer(DEFAULT_AGENT, prompt)
         try:
             match = re.search(r"\[\s*{.*}\s*\]", output, re.DOTALL)
             if match:
@@ -4315,7 +4316,7 @@ class TestQualityChecker:
             "\n".join(deterministic_issues) if not deterministic_issues else "Tier 1 passed"
         )
         prompt = PromptBuilder.test_quality_prompt(task, test_source, ast_report)
-        ai_output = self.ai_runner.run_reviewer("claude", prompt)
+        ai_output = self.ai_runner.run_reviewer(DEFAULT_AGENT, prompt)
 
         ai_issues = []
         hollow_tests = []

--- a/tests/test_ai_runner.py
+++ b/tests/test_ai_runner.py
@@ -136,7 +136,7 @@ def test_run_test_writer_uses_different_model():
     ai.run_test_writer("test prompt", Path("."))
 
     call_args = runner.run.call_args[0][0]
-    assert call_args[0] in ("claude", "gemini")
+    assert call_args[0] in ("opencode", "gemini")
 
 
 def test_run_reviewer_opencode_uses_reviewer_model():


### PR DESCRIPTION
## Summary

- Replace all 4 hardcoded `"claude"` agent calls with `DEFAULT_AGENT = "opencode"` constant
- Affected: `run_decompose()`, `run_test_writer()`, `_ralplan` critic, `TestQualityChecker` AI review
- Review quality retry order now puts opencode first (was gemini first when not opencode_only)
- Claude is still available via `--agent claude` — just no longer the default

## Why

Claude is expensive. Opencode models (kimi-k2.5 for review, minimax-m2.7 for test writing, big-pickle for coding) are cheaper and sufficient for most tasks. This makes opencode the default across all agent roles — decompose, review, test writing, and plan consensus — while keeping claude as an explicit opt-in.

## Test plan

- [x] 629/629 tests pass on this branch
- [x] `test_run_test_writer_uses_different_model` updated to expect `"opencode"` instead of `"claude"`